### PR TITLE
[LB-1330] fixed snapshot generating query for Astra

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ get ip
 
 `docker inspect mycassandra`
  
-start another instance for cqlsh
+start another instance for cqlsh, check for IP address, replace mentioned IP with the one inspect command shows
 
 `docker run -it --rm cassandra bash`
 

--- a/README.test-harness.md
+++ b/README.test-harness.md
@@ -16,9 +16,10 @@ To be able to run the harness tests locally setting up docker container is curre
 
 To create a local test database docker container, execute the following steps:
 - Run main cassandra instance `docker run -p 9042:9042 --rm --name mycassandra -d cassandra`, and give it few seconds to start
+- Run `docker inspect mycassandra` to get a main instance IP address. By default, it's 172.17.0.2 but may change in our local env.
 - To execute init script run second container `docker run -it --rm cassandra bash`
-- enter cql console `cqlsh 172.17.0.2`
-- copy and paste `test.cql` file content
+- enter cql console `cqlsh 172.17.0.2` (or other IP showed by `docker inspect mycassandra` if this doesn't work) 
+- copy and paste `test.cql` file content to create keyspace and tables for tests. 
 
 #### Executing the tests
 From your IDE, right click on the `LiquibaseHarnessSuiteTest` test class present in `src/test/groovy` directory. 

--- a/src/main/java/liquibase/ext/cassandra/snapshot/IndexSnapshotGeneratorCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/snapshot/IndexSnapshotGeneratorCassandra.java
@@ -38,7 +38,7 @@ public class IndexSnapshotGeneratorCassandra extends IndexSnapshotGenerator {
             Relation relation = (Relation) foundObject;
             Database database = snapshot.getDatabase();
 
-            String query = String.format("SELECT INDEX_NAME, OPTIONS FROM system_schema.indexes WHERE keyspace_name = '%s' AND TABLE_NAME='%s';",
+            String query = String.format("SELECT KEYSPACE_NAME, INDEX_NAME, OPTIONS FROM system_schema.indexes WHERE KEYSPACE_NAME = '%s' AND TABLE_NAME='%s';",
                     database.getDefaultCatalogName(), relation.getName());
             Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc",
                     database);
@@ -52,7 +52,8 @@ public class IndexSnapshotGeneratorCassandra extends IndexSnapshotGenerator {
     private Index readIndex(Map<String, ?> tableMap, Relation relation) {
         String indexName = StringUtil.trimToNull((String) tableMap.get("INDEX_NAME"));
         String options = StringUtil.trimToNull((String) tableMap.get("OPTIONS"));
-
+        // we don't really need KEYSPACE_NAME param in query to build Column obj, but Astra Cassandra implementation
+        // (and maybe some others) fails if it's missing
         Index index = new Index();
         index.setName(indexName);
         index.setRelation(relation);
@@ -85,7 +86,7 @@ public class IndexSnapshotGeneratorCassandra extends IndexSnapshotGenerator {
         Relation relation = ((Index) example).getRelation();
         Database database = snapshot.getDatabase();
 
-        String query = String.format("SELECT INDEX_NAME, OPTIONS FROM system_schema.indexes WHERE keyspace_name = '%s' AND TABLE_NAME='%s' AND INDEX_NAME= '%s';",
+        String query = String.format("SELECT KEYSPACE_NAME, INDEX_NAME, OPTIONS FROM system_schema.indexes WHERE KEYSPACE_NAME = '%s' AND TABLE_NAME='%s' AND INDEX_NAME= '%s';",
                 database.getDefaultCatalogName(), relation.getName(), example.getName());
         Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc",
                 database);


### PR DESCRIPTION
checked locally with manually created Astra account
added AWS_keyspace fix (excluded column name from query calling system_schema.columns)"



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-1415) by [Unito](https://www.unito.io/learn-more)
