### PR TITLE
[DAT-7299] fixed not null indicator for column snapshot, fixed snapshot tests

### DIFF
--- a/src/main/java/liquibase/ext/cassandra/snapshot/ColumnSnapshotGeneratorCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/snapshot/ColumnSnapshotGeneratorCassandra.java
@@ -83,7 +83,7 @@ public class ColumnSnapshotGeneratorCassandra extends ColumnSnapshotGenerator {
         column.setRelation(table);
         // Cassandra doesn't actually store somewhere separately if column could nullable or not,
         // but it doesn't allow primary keys to be missing, so gonna use this field as nullable indicator
-        column.setNullable("partition_key".equalsIgnoreCase(rawColumnKind));
+        column.setNullable(!"partition_key".equalsIgnoreCase(rawColumnKind));
         //TODO extend datatype parsing when needed to include DataTypeId
         column.setType(new DataType(rawColumnType));
         return column;

--- a/src/test/resources/liquibase/harness/snapshot/cassandra/column.groovy
+++ b/src/test/resources/liquibase/harness/snapshot/cassandra/column.groovy
@@ -1,0 +1,37 @@
+package liquibase.harness.snapshot.cassandra
+
+import liquibase.harness.snapshot.SnapshotTest
+import liquibase.snapshot.DatabaseSnapshot
+import liquibase.structure.core.Column
+import liquibase.structure.core.Table
+
+[
+        [
+                setup : "create table test_table (test_col int PRIMARY KEY)",
+                verify: {
+                    DatabaseSnapshot snapshot ->
+                        snapshot.get(new Column(Table.class, null, null, "test_table", "test_col")).with {
+                            assert type.typeName.toLowerCase().startsWith("int")
+                        }
+
+                }
+        ],
+        [
+                setup : "create table test_table (test_col varchar PRIMARY KEY)",
+                verify: {
+                    DatabaseSnapshot snapshot ->
+                        snapshot.get(new Column(Table.class, null, null, "test_table", "test_col")).with {
+                            assert type.typeName.toLowerCase() == "text"
+                        }
+                }
+        ],
+        [
+                setup : "create table test_table (test_col int PRIMARY KEY)",
+                verify: { DatabaseSnapshot snapshot ->
+                    snapshot.get(new Column(Table.class, null, null, "test_table", "test_col")).with {
+                        assert !nullable
+                    }
+                }
+        ],
+] as SnapshotTest.TestConfig[]
+

--- a/src/test/resources/liquibase/harness/snapshot/cassandra/table.groovy
+++ b/src/test/resources/liquibase/harness/snapshot/cassandra/table.groovy
@@ -1,0 +1,18 @@
+package liquibase.harness.snapshot.cassandra
+
+import liquibase.harness.snapshot.SnapshotTest
+import liquibase.snapshot.DatabaseSnapshot
+import liquibase.structure.core.Table
+
+[
+        [
+                setup : "create table test_table (test_col int PRIMARY KEY, col2 varchar)",
+                verify: {
+                    DatabaseSnapshot snapshot ->
+                        snapshot.get(new Table(name: "test_table")).with {
+                            assert name.equalsIgnoreCase("test_table")
+                            assert columns*.name.containsAll(["test_col", "col2"])
+                        }
+                }
+        ],
+] as SnapshotTest.TestConfig[]


### PR DESCRIPTION
default snapshot tests from test-harness don't work for Cassandra as 
1) All tables should have primary keys
2) Cassandra doesn't support precision or varchar length
3) Cassandra doesn't support not null constraints, however primary keys can't be missing. So we could count on primary key indication for column to serve as not nullable indicator while building snapshot.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-1782) by [Unito](https://www.unito.io)
