### PR TITLE
Cassandra 3.11

### DIFF
--- a/src/test/resources/harness-config.yml
+++ b/src/test/resources/harness-config.yml
@@ -9,3 +9,10 @@ databasesUnderTest:
     username: cassandra
     password: cassandra
     dbSchema: betterbotz
+#
+#  - name: cassandra
+#    version: 4.0
+#    url: jdbc:cassandra://localhost:9043;DefaultKeyspace=betterbotz
+#    username: cassandra
+#    password: cassandra
+#    dbSchema: betterbotz

--- a/src/test/resources/liquibase/harness/change/changelogs/cassandra/createTableTimestamp.xml
+++ b/src/test/resources/liquibase/harness/change/changelogs/cassandra/createTableTimestamp.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <changeSet id="1" author="oleh">
+        <createTable tableName="test_table_timestamp">
+            <column name="test_id" type="int">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="test_column" type="timestamp"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/resources/liquibase/harness/change/changelogs/cassandra/dropTable.xml
+++ b/src/test/resources/liquibase/harness/change/changelogs/cassandra/dropTable.xml
@@ -14,7 +14,10 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-            <dropTable tableName="test_table"/>
+        <rollback/>
+    </changeSet>
+    <changeSet author="r2" id="2">
+        <dropTable tableName="test_table"/>
         <rollback/>
     </changeSet>
 </databaseChangeLog>

--- a/src/test/resources/liquibase/harness/change/expectedSnapshot/cassandra/createTableTimestamp.json
+++ b/src/test/resources/liquibase/harness/change/expectedSnapshot/cassandra/createTableTimestamp.json
@@ -1,0 +1,23 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Table": [
+        {
+          "table": {
+            "name": "test_table_timestamp"
+          }
+        }
+      ],
+      "liquibase.structure.core.Column": [
+        {
+          "column": {
+            "name": "test_id"
+          },
+          "column": {
+            "name": "test_column"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/liquibase/harness/change/expectedSql/cassandra/createProcedure.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cassandra/createProcedure.sql
@@ -1,0 +1,2 @@
+INVALID TEST
+-- Cassandra does not support stored procedures

--- a/src/test/resources/liquibase/harness/change/expectedSql/cassandra/createProcedureFromFile.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cassandra/createProcedureFromFile.sql
@@ -1,0 +1,2 @@
+INVALID TEST
+-- Cassandra does not support stored procedures

--- a/src/test/resources/liquibase/harness/change/expectedSql/cassandra/createTableTimestamp.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cassandra/createTableTimestamp.sql
@@ -1,0 +1,1 @@
+CREATE TABLE test_table_timestamp (test_id INT, test_column TIMESTAMP, PRIMARY KEY (test_id))

--- a/src/test/resources/liquibase/harness/change/expectedSql/cassandra/createTableTimestamp.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cassandra/createTableTimestamp.sql
@@ -1,1 +1,1 @@
-CREATE TABLE test_table_timestamp (test_id INT, test_column TIMESTAMP, PRIMARY KEY (test_id))
+CREATE TABLE test_table_timestamp (test_id INT, test_column timestamp, PRIMARY KEY (test_id))

--- a/src/test/resources/liquibase/harness/change/expectedSql/cassandra/dropProcedure.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cassandra/dropProcedure.sql
@@ -1,0 +1,2 @@
+INVALID TEST
+-- Cassandra does not support stored procedures


### PR DESCRIPTION
Resolve issues with existing Cassandra 3.11 tests. Once all green, we can start working on Cassandra 4.0.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-1783) by [Unito](https://www.unito.io)
