### PR TITLE
Obtain database connection to Cassandra with username and password (LB-2115)

### DIFF
--- a/src/main/java/liquibase/ext/cassandra/changelog/CassandraChangeLogHistoryService.java
+++ b/src/main/java/liquibase/ext/cassandra/changelog/CassandraChangeLogHistoryService.java
@@ -30,22 +30,7 @@ public class CassandraChangeLogHistoryService extends StandardChangeLogHistorySe
 
     @Override
     public boolean hasDatabaseChangeLogTable() {
-        boolean hasChangeLogTable;
-        try {
-            Statement statement = ((CassandraDatabase) getDatabase()).getStatement();
-            statement.executeQuery("select ID from " + getDatabase().getDefaultCatalogName() + ".DATABASECHANGELOG");
-            statement.close();
-            hasChangeLogTable = true;
-        } catch (SQLException e) {
-            Scope.getCurrentScope().getLog(getClass()).info("No DATABASECHANGELOG available in cassandra.");
-            hasChangeLogTable = false;
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-            hasChangeLogTable = false;
-        }
-
-        // needs to be generated up front
-        return hasChangeLogTable;
+        return ((CassandraDatabase)getDatabase()).hasDatabaseChangeLogLockTable();
     }
 
 
@@ -62,7 +47,7 @@ public class CassandraChangeLogHistoryService extends StandardChangeLogHistorySe
             }
             statement.close();
 
-        } catch (SQLException | ClassNotFoundException e) {
+        } catch (SQLException | DatabaseException e) {
             e.printStackTrace();
         }
         return next + 1;

--- a/src/main/java/liquibase/ext/cassandra/lockservice/LockServiceCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/lockservice/LockServiceCassandra.java
@@ -140,22 +140,7 @@ public class LockServiceCassandra extends StandardLockService {
 
     @Override
     public boolean hasDatabaseChangeLogLockTable() {
-        boolean hasChangeLogLockTable;
-        try {
-            Statement statement = ((CassandraDatabase) database).getStatement();
-            statement.executeQuery("SELECT ID from " + database.getDefaultCatalogName() + ".DATABASECHANGELOGLOCK");
-            statement.close();
-            hasChangeLogLockTable = true;
-        } catch (SQLException e) {
-            Scope.getCurrentScope().getLog(getClass()).info("No DATABASECHANGELOGLOCK available in cassandra.");
-            hasChangeLogLockTable = false;
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-            hasChangeLogLockTable = false;
-        }
-
-        // needs to be generated up front
-        return hasChangeLogLockTable;
+        return ((CassandraDatabase)database).hasDatabaseChangeLogLockTable();
     }
 
     @Override


### PR DESCRIPTION
This fixes the issue preventing Liquibase with Cassandra Extension from working when Cassandra has a username and password. Without this fix, a connection was established to Cassandra without the username and password, only the URL, which is obviously forbidden.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2171) by [Unito](https://www.unito.io)
