### PR TITLE
Don't force cassandra driver on all databases

### DIFF
--- a/src/main/java/liquibase/ext/cassandra/database/CassandraDatabase.java
+++ b/src/main/java/liquibase/ext/cassandra/database/CassandraDatabase.java
@@ -59,7 +59,10 @@ public class CassandraDatabase extends AbstractJdbcDatabase {
 
 	@Override
 	public String getDefaultDriver(String url) {
-		return "com.simba.cassandra.jdbc42.Driver";
+		if (url.startsWith("jdbc:cassandra:")) {
+			return "com.simba.cassandra.jdbc42.Driver";
+		}
+		return null;
 	}
 
 	@Override

--- a/src/main/java/liquibase/ext/cassandra/database/CassandraDatabase.java
+++ b/src/main/java/liquibase/ext/cassandra/database/CassandraDatabase.java
@@ -59,7 +59,7 @@ public class CassandraDatabase extends AbstractJdbcDatabase {
 
 	@Override
 	public String getDefaultDriver(String url) {
-		if (url.startsWith("jdbc:cassandra:")) {
+		if (String.valueOf(url).startsWith("jdbc:cassandra:")) {
 			return "com.simba.cassandra.jdbc42.Driver";
 		}
 		return null;

--- a/src/main/java/liquibase/ext/cassandra/sqlgenerator/TagDatabaseGeneratorCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/sqlgenerator/TagDatabaseGeneratorCassandra.java
@@ -15,6 +15,7 @@ import liquibase.Scope;
 import liquibase.database.Database;
 import liquibase.database.ObjectQuotingStrategy;
 import liquibase.datatype.DataTypeFactory;
+import liquibase.exception.DatabaseException;
 import liquibase.ext.cassandra.database.CassandraDatabase;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
@@ -79,13 +80,7 @@ public class TagDatabaseGeneratorCassandra extends TagDatabaseGenerator {
 
 			
 
-		} catch (SQLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-			return super.generateSql(statement, database, sqlGeneratorChain);
-		} catch (ClassNotFoundException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+		} catch (SQLException | DatabaseException e) {
 			return super.generateSql(statement, database, sqlGeneratorChain);
 		} finally {
 			database.setObjectQuotingStrategy(currentStrategy);

--- a/src/test/groovy/liquibase/ext/cassandra/database/CassandraDatabaseTest.groovy
+++ b/src/test/groovy/liquibase/ext/cassandra/database/CassandraDatabaseTest.groovy
@@ -9,4 +9,11 @@ class CassandraDatabaseTest extends Specification {
         new CassandraDatabase().getShortName() == "cassandra"
     }
 
+    def getDefaultDriver() {
+        expect:
+        new CassandraDatabase().getDefaultDriver(null) == null
+        new CassandraDatabase().getDefaultDriver("jdbc:mysql://localhost") == null
+        new CassandraDatabase().getDefaultDriver("jdbc:cassandra://localhost") != null
+    }
+
 }


### PR DESCRIPTION
## Description

Database class implementations need to return "null" for databases they don't speak for, but CassandraDatabase does not do that. 

This means that anyone including the cassandra extension in their lib dir will have to specify the "liquibase.driver" setting if they ever use liquibase for a different database type.