### PR TITLE
Correctly initialize lock service

### DIFF
--- a/src/main/java/liquibase/ext/cassandra/sqlgenerator/InitializeDatabaseChangeLogLockTableGeneratorCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/sqlgenerator/InitializeDatabaseChangeLogLockTableGeneratorCassandra.java
@@ -6,7 +6,9 @@ import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.sqlgenerator.core.InitializeDatabaseChangeLogLockTableGenerator;
+import liquibase.statement.SqlStatement;
 import liquibase.statement.core.InitializeDatabaseChangeLogLockTableStatement;
+import liquibase.statement.core.InsertStatement;
 import liquibase.statement.core.RawSqlStatement;
 
 public class InitializeDatabaseChangeLogLockTableGeneratorCassandra extends InitializeDatabaseChangeLogLockTableGenerator {
@@ -29,7 +31,11 @@ public class InitializeDatabaseChangeLogLockTableGeneratorCassandra extends Init
                 database.getLiquibaseSchemaName(),
                 database.getDatabaseChangeLogLockTableName().toUpperCase()));
 
-        return SqlGeneratorFactory.getInstance().generateSql(deleteStatement, database);
+        InsertStatement insertStatement = new InsertStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogLockTableName().toUpperCase())
+                .addColumnValue("ID", 1)
+                .addColumnValue("LOCKED", Boolean.FALSE);
+
+        return SqlGeneratorFactory.getInstance().generateSql(new SqlStatement[]{deleteStatement, insertStatement}, database);
 
     }
 


### PR DESCRIPTION
## Description

The lock service was not correctly inserting the "not locked" entry into the databasechangelog table. 

Fixes #140