### PR TITLE
Shaded slf4j-jdk14 to work with simba driver's shaded slf4j-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,13 @@
             <version>1.30</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.36</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -209,6 +216,42 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <!-- the simba driver shades its slf4j, so we shade the slf4j-jdk14 binding to avoid the "can't find binding" error -->
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>create-module-jar</id>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <filters>
+                                <filter>
+                                    <artifact>org.slf4j:slf4j-jdk14</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.slf4j:slf4j-jdk14</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.slf4j</pattern>
+                                    <shadedPattern>com.simba.cassandra.shaded.slf4j</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
     </build>


### PR DESCRIPTION
## Description

When running Liquibase with the simba driver, we get a:
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```
warning.

The way it is **supposed** to work is that you just have to add the slf4j binding jar you want. In our case, add the jar from https://mvnrepository.com/artifact/org.slf4j/slf4j-jdk14/ to your liquibase lib directory.

BUT: the datastax simba driver has shaded the slf4j dependency into a com.simba.cassandra.shaded.slf4j package and so the normal slf4j logic has been updated to look for a com/simba/cassandra/shaded/slf4j/impl/StaticLoggerBinder.class which is not valid in slf4j-jdk14 and so even with that jar file you get the binding error.

This PR shades the slf4j-jdk14 dependency into the liquibase-cassandra extension using the com.simba.cassandra.shaded.slf4j package so it gets found and the message goes away.