### PR TITLE
Fix CassandraDatabase default driver

### DIFF
--- a/src/main/java/liquibase/ext/cassandra/database/CassandraDatabase.java
+++ b/src/main/java/liquibase/ext/cassandra/database/CassandraDatabase.java
@@ -19,6 +19,7 @@ public class CassandraDatabase extends AbstractJdbcDatabase {
 	public static final String SHORT_PRODUCT_NAME = "cassandra";
 	public static final Integer DEFAULT_PORT = 9160;
 	public static final String DEFAULT_DRIVER = "com.simba.cassandra.jdbc42.Driver";
+	public static final String NO_JDBC_VERSION_DRIVER = "com.simba.cassandra.jdbc.Driver";
 
 	private String keyspace;
 
@@ -66,7 +67,12 @@ public class CassandraDatabase extends AbstractJdbcDatabase {
 	@Override
 	public String getDefaultDriver(String url) {
 		if (String.valueOf(url).startsWith("jdbc:cassandra:")) {
-			return DEFAULT_DRIVER;
+			try {
+                Class.forName(DEFAULT_DRIVER);
+                return DEFAULT_DRIVER;
+            } catch (ClassNotFoundException e) {
+				return NO_JDBC_VERSION_DRIVER;
+			}
 		}
 		return null;
 	}

--- a/src/main/java/liquibase/ext/cassandra/database/CassandraDatabase.java
+++ b/src/main/java/liquibase/ext/cassandra/database/CassandraDatabase.java
@@ -18,7 +18,7 @@ public class CassandraDatabase extends AbstractJdbcDatabase {
 	public static final String PRODUCT_NAME = "Cassandra";
 	public static final String SHORT_PRODUCT_NAME = "cassandra";
 	public static final Integer DEFAULT_PORT = 9160;
-	public static final String DEFULT_DRIVER = "com.simba.cassandra.jdbc.Driver";
+	public static final String DEFAULT_DRIVER = "com.simba.cassandra.jdbc42.Driver";
 
 	private String keyspace;
 
@@ -66,7 +66,7 @@ public class CassandraDatabase extends AbstractJdbcDatabase {
 	@Override
 	public String getDefaultDriver(String url) {
 		if (String.valueOf(url).startsWith("jdbc:cassandra:")) {
-			return DEFULT_DRIVER;
+			return DEFAULT_DRIVER;
 		}
 		return null;
 	}


### PR DESCRIPTION
On a previous repo cleanup, the default Cassandra JDBC driver was mistakenly refactored to `com.simba.cassandra.jdbc.Driver`, hence throwing errors when a 3rd app was not explicitly specifying another driver. This commit amends the default to the previous one of `com.simba.cassandra.jdbc42.Driver`