### PR TITLE
DAT-16149 DevOps :: Extensions Release Failing

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -8,5 +8,5 @@ on:
 jobs:
 
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.3
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.5
     secrets: inherit

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,5 +11,5 @@ permissions:
   
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.3
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.5
     secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -11,5 +11,5 @@ permissions:
   
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.3
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.5
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build:
-    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.3
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.5
     secrets: inherit
 
   integration-tests:

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,13 @@
         <sonar.tests>src/test/groovy</sonar.tests>
     </properties>
 
+    <scm>
+        <connection>scm:git:${project.scm.url}</connection>
+        <developerConnection>scm:git:${project.scm.url}</developerConnection>
+		<url>https://github.com/liquibase/liquibase-cassandra.git</url>
+		<tag>HEAD</tag>
+	</scm>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
…nsion version to v0.5.5

chore(create-release.yml): update liquibase/build-logic extension version to v0.5.5
chore(release-published.yml): update liquibase/build-logic extension version to v0.5.5
chore(test.yml): update liquibase/build-logic extension version to v0.5.5
chore(pom.xml): add SCM information for liquibase-cassandra repository