### PR TITLE
Fix issue #242

### DIFF
--- a/src/main/java/liquibase/ext/cassandra/database/CassandraDatabase.java
+++ b/src/main/java/liquibase/ext/cassandra/database/CassandraDatabase.java
@@ -111,7 +111,10 @@ public class CassandraDatabase extends AbstractJdbcDatabase {
 	public String getKeyspace() {
 		if (keyspace == null) {
 			try {
-				keyspace = ((CassandraConnection) (this).getConnection()).getSession().getKeyspace().toString();
+				if (this.getConnection() instanceof JdbcConnection) {
+					keyspace = ((CassandraConnection) ((JdbcConnection) this.getConnection())
+							.getUnderlyingConnection()).getSchema();
+				}
 			} catch (Exception e) {
 				Scope.getCurrentScope().getLog(CassandraDatabase.class)
 						.severe("Could not get keyspace from connection", e);


### PR DESCRIPTION
In this fix, we cast the connection to `JdbcConnection`, then the underlying connection to `CassandraConnection` to retrieve the keyspace. This is very similar to what was done in previous versions with Simba driver.

The fix has been tested locally by myself and other users ("I also tested locally with your fix for the `java.lang.ClassCastException`. This indeed fixed the logs and I do not see the exceptions anymore"  ([source](https://github.com/ing-bank/cassandra-jdbc-wrapper/discussions/37#discussioncomment-7624316)) and also [see here](https://github.com/liquibase/liquibase-cassandra/issues/214#issuecomment-1821393543))

Do you think it would be possible to integrate this fix into a patch version (because version 4.25.0 is unusable as is for most users)?