### PR TITLE
Update Liquibase Cassandra extension version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.liquibase.ext</groupId>
     <artifactId>liquibase-cassandra</artifactId>
-    <version>4.26.0-SNAPSHOT</version>
+    <version>4.25.0.1-SNAPSHOT</version>
     <name>Liquibase Extension: Cassandra Database Support</name>
     <description>Adds support for Cassandra database</description>
     <url>https://github.com/liquibase/liquibase-cassandra</url>


### PR DESCRIPTION
The version of the Liquibase Cassandra extension has been downgraded from 4.26.0-SNAPSHOT to 4.25.0.1-SNAPSHOT in the project's pom.xml file. This may be due to stability or compatibility requirements with other project dependencies.