### PR TITLE
Fix maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,6 @@
             <version>4.11.0</version>
         </dependency>
         <dependency>
-          <groupId>com.datastax.oss</groupId>
-          <artifactId>java-driver-parent</artifactId>
-          <version>4.17.0</version>
-          <type>pom</type>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>2.2.224</version>


### PR DESCRIPTION
`com.datastax.oss:java-driver-parent:pom` is not meant to be pulled as a dependency (see https://docs.datastax.com/en/developer/java-driver/4.17/#getting-the-driver)

However, `com.datastax.oss:java-driver-core:jar`, `com.datastax.oss:java-driver-query-builder:jar`, `com.datastax.oss:java-driver-mapper-runtime:jar` are.

`liquibase-cassandra` only uses the first one of those three, and it's already pulled as a transitive dependency of `com.ing.data:cassandra-jdbc-wrapper:jar`, so no need to repeat it in `liquibase-cassandra`'s pom neither.

A diff of `mvn dependency:list -Dsort` output before and after the change shows that only `com.datastax.oss:java-driver-parent:pom` is removed

```diff
 [INFO]    com.athaydes:spock-reports:jar:1.3.1:test -- module spock.reports (auto)
 [INFO]    com.datastax.oss:java-driver-core:jar:4.17.0:compile -- module java.driver.core (auto)
-[INFO]    com.datastax.oss:java-driver-parent:pom:4.17.0:compile
 [INFO]    com.datastax.oss:java-driver-shaded-guava:jar:25.1-jre-graal-sub-1:compile -- module java.driver.shaded.guava (auto)
 [INFO]    com.datastax.oss:native-protocol:jar:1.5.1:compile -- module com.datastax.oss.protocol [auto]
 [INFO]    com.fasterxml.jackson.core:jackson-annotations:jar:2.15.2:compile -- module com.fasterxml.jackson.annotation
 [INFO]    com.fasterxml.jackson.core:jackson-core:jar:2.16.0:compile -- module com.fasterxml.jackson.core
 [INFO]    com.fasterxml.jackson.core:jackson-databind:jar:2.15.2:compile -- module com.fasterxml.jackson.databind
 [INFO]    com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.16.0:compile -- module com.fasterxml.jackson.datatype.jsr310
 [INFO]    com.github.ben-manes.caffeine:caffeine:jar:2.9.3:compile -- module com.github.benmanes.caffeine [auto]
 [INFO]    com.github.jnr:jffi:jar:1.3.9:compile -- module org.jnrproject.jffi [auto]
 [INFO]    com.github.jnr:jffi:jar:native:1.3.9:runtime -- module org.jnrproject.jffi.nativelibs [auto]
 [INFO]    com.github.jnr:jnr-a64asm:jar:1.0.0:compile -- module jnr.a64asm (auto)
 [INFO]    com.github.jnr:jnr-constants:jar:0.10.3:compile -- module org.jnrproject.constants [auto]
 [INFO]    com.github.jnr:jnr-ffi:jar:2.2.11:compile -- module org.jnrproject.ffi [auto]
 [INFO]    com.github.jnr:jnr-posix:jar:3.1.15:compile -- module org.jnrproject.posix [auto]
 [INFO]    com.github.jnr:jnr-x86asm:jar:1.0.2:compile -- module jnr.x86asm (auto)
 [INFO]    com.github.spotbugs:spotbugs-annotations:jar:3.1.12:compile -- module com.github.spotbugs.annotations [auto]
 [INFO]    com.github.stephenc.jcip:jcip-annotations:jar:1.0-1:compile -- module jcip.annotations (auto)
 [INFO]    com.google.code.findbugs:jsr305:jar:3.0.2:compile -- module jsr305 (auto)
 [INFO]    com.google.errorprone:error_prone_annotations:jar:2.10.0:compile -- module com.google.errorprone.annotations [auto]
 [INFO]    com.h2database:h2:jar:2.2.224:test -- module com.h2database [auto]
 [INFO]    com.ing.data:cassandra-jdbc-wrapper:jar:4.11.0:compile -- module cassandra.jdbc.wrapper (auto)
 [INFO]    com.opencsv:opencsv:jar:5.9:provided -- module com.opencsv [auto]
 [INFO]    com.typesafe:config:jar:1.4.1:compile -- module typesafe.config [auto]
 [INFO]    commons-io:commons-io:jar:2.14.0:compile -- module org.apache.commons.io
 [INFO]    io.dropwizard.metrics:metrics-core:jar:4.1.18:compile -- module com.codahale.metrics [auto]
 [INFO]    io.netty:netty-buffer:jar:4.1.94.Final:compile -- module io.netty.buffer [auto]
 [INFO]    io.netty:netty-codec:jar:4.1.94.Final:compile -- module io.netty.codec [auto]
 [INFO]    io.netty:netty-common:jar:4.1.94.Final:compile -- module io.netty.common [auto]
 [INFO]    io.netty:netty-handler:jar:4.1.94.Final:compile -- module io.netty.handler [auto]
 [INFO]    io.netty:netty-resolver:jar:4.1.94.Final:compile -- module io.netty.resolver [auto]
 [INFO]    io.netty:netty-transport-native-unix-common:jar:4.1.94.Final:compile -- module io.netty.transport.unix.common [auto]
 [INFO]    io.netty:netty-transport:jar:4.1.94.Final:compile -- module io.netty.transport [auto]
 [INFO]    javax.xml.bind:jaxb-api:jar:2.3.1:provided -- module java.xml.bind
 [INFO]    junit:junit:jar:4.13.2:test -- module junit [auto]
 [INFO]    org.apache.commons:commons-collections4:jar:4.4:compile -- module org.apache.commons.collections4 [auto]
 [INFO]    org.apache.commons:commons-lang3:jar:3.14.0:compile -- module org.apache.commons.lang3
 [INFO]    org.apache.commons:commons-text:jar:1.11.0:provided -- module org.apache.commons.text
 [INFO]    org.checkerframework:checker-qual:jar:3.19.0:compile -- module org.checkerframework.checker.qual [auto]
 [INFO]    org.codehaus.groovy:groovy-all:jar:2.4.15:test
 [INFO]    org.codehaus.groovy:groovy-all:pom:2.4.17:test
 [INFO]    org.hamcrest:hamcrest-core:jar:1.3:test -- module hamcrest.core (auto)
 [INFO]    org.hdrhistogram:HdrHistogram:jar:2.1.12:compile -- module HdrHistogram (auto)
 [INFO]    org.liquibase:liquibase-commercial:jar:4.26.0:provided -- module liquibase.commercial (auto)
 [INFO]    org.liquibase:liquibase-core:jar:4.26.0:provided -- module liquibase.core [auto]
 [INFO]    org.liquibase:liquibase-test-harness:jar:1.0.9:test -- module liquibase.test.harness (auto)
 [INFO]    org.ow2.asm:asm-analysis:jar:9.2:compile -- module org.objectweb.asm.tree.analysis
 [INFO]    org.ow2.asm:asm-commons:jar:9.2:compile -- module org.objectweb.asm.commons
 [INFO]    org.ow2.asm:asm-tree:jar:9.2:compile -- module org.objectweb.asm.tree
 [INFO]    org.ow2.asm:asm-util:jar:9.2:compile -- module org.objectweb.asm.util
 [INFO]    org.ow2.asm:asm:jar:9.2:compile -- module org.objectweb.asm
 [INFO]    org.reactivestreams:reactive-streams:jar:1.0.3:compile -- module org.reactivestreams [auto]
 [INFO]    org.semver4j:semver4j:jar:5.2.2:compile -- module org.semver4j [auto]
 [INFO]    org.slf4j:slf4j-api:jar:2.0.9:compile -- module org.slf4j
 [INFO]    org.slf4j:slf4j-simple:jar:2.0.9:compile -- module org.slf4j.simple
 [INFO]    org.spockframework:spock-core:jar:1.3-groovy-2.4:test -- module org.spockframework.core [auto]
 [INFO]    org.yaml:snakeyaml:jar:2.2:test -- module org.yaml.snakeyaml
```