### PR TITLE
Fix/4.27.0 release

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -4,10 +4,6 @@ on:
   workflow_dispatch:
   release:
     types: [published]
-
-permissions:
-  contents: write
-  pull-requests: write
   
 jobs:
   release:

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -7,5 +7,5 @@ on:
   
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.6.7
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.6.8
     secrets: inherit


### PR DESCRIPTION
fix: `.github/workflows/release-published.yml`: fix error `[Invalid workflow file: .github/workflows/release-published.yml#L13](https://github.com/liquibase/liquibase-cassandra/actions/runs/8468509892/workflow)
The workflow is not valid. .github/workflows/release-published.yml (Line: 13, Col: 3): Error calling workflow 'liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.6.7'. The nested job 'deploy_xsd' is requesting 'id-token: write', but is only allowed 'id-token: none'.`