### PR TITLE
Fix issue #278: add compliancemode parameter in JDBC URL if absent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,12 @@
             <version>2.2.224</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.14.15</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/liquibase/ext/cassandra/database/CassandraDatabaseConnection.java
+++ b/src/main/java/liquibase/ext/cassandra/database/CassandraDatabaseConnection.java
@@ -1,0 +1,65 @@
+package liquibase.ext.cassandra.database;
+
+import com.ing.data.cassandra.jdbc.CassandraDriver;
+import liquibase.Scope;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.DatabaseException;
+
+import java.net.URI;
+import java.sql.Driver;
+import java.util.Properties;
+
+public class CassandraDatabaseConnection extends JdbcConnection {
+
+    @Override
+    public int getPriority() {
+        return 201;
+    }
+
+    @Override
+    public void open(String url, Driver driverObject, Properties driverProperties) throws DatabaseException {
+        String jdbcUrl = url;
+
+        // When using Cassandra with com.ing.data.cassandra.jdbc.CassandraDriver, it is required to specify the
+        // compliance mode "Liquibase" in the JDBC URL. So, do it by default when it's necessary.
+        if (driverObject instanceof CassandraDriver) {
+            try {
+                boolean complianceModePresent = false;
+                final String liquibaseComplianceModeParameter = "compliancemode=Liquibase";
+                // Replace the actual protocol (jdbc:cassandra:// or any other) by a valid protocol for URI
+                // parsing (jdbc://)
+                final int protocolEndIdx = jdbcUrl.indexOf("://");
+                final String parseableUrl = "jdbc" + jdbcUrl.substring(protocolEndIdx);
+                final URI jdbcUri = URI.create(parseableUrl);
+                final String queryPart = jdbcUri.getQuery();
+                if (queryPart != null) {
+                    String[] queryParams = queryPart.split("&");
+                    for (String queryParam : queryParams) {
+                        if (liquibaseComplianceModeParameter.equals(queryParam)) {
+                            complianceModePresent = true;
+                            break;
+                        }
+                    }
+                    if (!complianceModePresent) {
+                        jdbcUrl += "&" + liquibaseComplianceModeParameter;
+                    }
+                } else {
+                    jdbcUrl += "?" + liquibaseComplianceModeParameter;
+                }
+                Scope.getCurrentScope().getLog(CassandraDatabaseConnection.class)
+                        .info("Connecting to Cassandra using: " + jdbcUrl);
+            } catch (IllegalArgumentException e) {
+                Scope.getCurrentScope().getLog(CassandraDatabaseConnection.class)
+                        .warning("Unable to check compliance mode in JDBC URL, connecting with configured URL. "
+                                + "The compliance mode might be incorrect.");
+            }
+        }
+
+        openConnection(jdbcUrl, driverObject, driverProperties);
+    }
+
+    void openConnection(String url, Driver driverObject, Properties driverProperties) throws DatabaseException {
+        super.open(url, driverObject, driverProperties);
+    }
+
+}

--- a/src/main/resources/META-INF/services/liquibase.database.DatabaseConnection
+++ b/src/main/resources/META-INF/services/liquibase.database.DatabaseConnection
@@ -1,0 +1,1 @@
+liquibase.ext.cassandra.database.CassandraDatabaseConnection

--- a/src/test/groovy/liquibase/ext/cassandra/database/CassandraDatabaseConnectionTest.groovy
+++ b/src/test/groovy/liquibase/ext/cassandra/database/CassandraDatabaseConnectionTest.groovy
@@ -1,0 +1,39 @@
+package liquibase.ext.cassandra.database
+
+import com.ing.data.cassandra.jdbc.CassandraDriver
+import liquibase.exception.DatabaseException
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.sql.Driver
+
+class CassandraDatabaseConnectionTest extends Specification {
+
+    @Unroll
+    def "open with #url"() {
+        given:
+        def cassandraConnection = Spy(new CassandraDatabaseConnection() {
+            // Overriding the real connection call, we just want to test it's called with the expected URL.
+            @Override
+            void openConnection(String jdbcUrl, Driver driverObject, Properties driverProperties) throws DatabaseException {
+                println("Mock open connection with URL: $jdbcUrl")
+            }
+        })
+        def cassandraDriver = new CassandraDriver()
+        def cassandraDriverProperties = new Properties()
+
+        when:
+        cassandraConnection.open(url, cassandraDriver, cassandraDriverProperties)
+
+        then:
+        1 * cassandraConnection.openConnection(expectedUrl, cassandraDriver, cassandraDriverProperties)
+
+        where:
+        url                                                                                               | expectedUrl
+        "jdbc:cassandra://localhost:9042/betterbotz?compliancemode=Liquibase&localdatacenter=datacenter1" | "jdbc:cassandra://localhost:9042/betterbotz?compliancemode=Liquibase&localdatacenter=datacenter1"
+        "jdbc:cassandra://localhost:9042/betterbotz?localdatacenter=datacenter1"                          | "jdbc:cassandra://localhost:9042/betterbotz?localdatacenter=datacenter1&compliancemode=Liquibase"
+        "jdbc:cassandra://localhost:9042/betterbotz"                                                      | "jdbc:cassandra://localhost:9042/betterbotz?compliancemode=Liquibase"
+
+    }
+
+}


### PR DESCRIPTION
This closes #278 

This adds a `CassandraDatabaseConnection` implementation for `DatabaseConnection` interface, extending `JdbcConnection`. In this implementation, the compliance mode parameter `Liquibase` is added to the JDBC URL if necessary when the used JDBC driver is `com.ing.data.cassandra.jdbc.CassandraDriver`.