### PR TITLE
Add compatibility mode for AWS Keyspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-liquibase-cassandra[![Build and Test Extention](https://github.com/liquibase/liquibase-cassandra/actions/workflows/build.yml/badge.svg)](https://github.com/liquibase/liquibase-cassandra/actions/workflows/build.yml)
+liquibase-cassandra [![Build and Test Extension](https://github.com/liquibase/liquibase-cassandra/actions/workflows/test.yml/badge.svg)](https://github.com/liquibase/liquibase-cassandra/actions/workflows/test.yml)
 ===================
 
 Liquibase extension for Cassandra Support.
@@ -88,19 +88,19 @@ INSERT INTO posts(id, author_id, title, description, content, inserted_date) VAL
 INSERT INTO posts(id, author_id, title, description, content, inserted_date) VALUES
 (4,4,'itaque','deleniti','Magni nam optio id recusandae.','2010-07-28');
 INSERT INTO posts(id, author_id, title, description, content, inserted_date) VALUES
-(5,5,'ad','similique','Rerum tempore quis ut nesciunt qui excepturi est.','2006-10-09');;
+(5,5,'ad','similique','Rerum tempore quis ut nesciunt qui excepturi est.','2006-10-09');
 ```
 
 #### Executing the tests
 First you need to build project - `mvn package` will do the job.
 
 ##### from IDE
-From your IDE, right click on the `liquibase.ext.cassandra.LiquibaseHarnessSuiteIT` test class present in `src/test/groovy` directory.
+From your IDE, right-click on the `liquibase.ext.cassandra.LiquibaseHarnessSuiteIT` test class present in `src/test/groovy` directory.
 Doing so, will allow you to execute all the standard change object tests in the liquibase-test-harness as well as the
 Cassandra specific change objects tests created exclusively to test this extension (You can find this in the
 `src/test/resources/liquibase/harness/change/changelogs/cassandra` directory).
 
-To run single test case, let's say `addColumn`, create JUit configuration for `liquibase.harness.change.ChangeObjectTests` with arg `-DchangeObjects=addColumn`
+To run single test case, let's say `addColumn`, create JUnit configuration for `liquibase.harness.change.ChangeObjectTests` with arg `-DchangeObjects=addColumn`
 More details about different options can be found in [liquibase-test-harness readme](https://github.com/liquibase/liquibase-test-harness)
 
 ##### from command line

--- a/src/main/java/liquibase/ext/cassandra/database/CassandraDatabaseConnection.java
+++ b/src/main/java/liquibase/ext/cassandra/database/CassandraDatabaseConnection.java
@@ -13,7 +13,7 @@ public class CassandraDatabaseConnection extends JdbcConnection {
 
     @Override
     public int getPriority() {
-        return 201;
+        return PRIORITY_DATABASE + 200;
     }
 
     @Override

--- a/src/main/java/liquibase/ext/cassandra/sqlgenerator/CreateDatabaseChangeLogLockTableGeneratorCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/sqlgenerator/CreateDatabaseChangeLogLockTableGeneratorCassandra.java
@@ -24,12 +24,20 @@ public class CreateDatabaseChangeLogLockTableGeneratorCassandra extends CreateDa
     @Override
     public Sql[] generateSql(CreateDatabaseChangeLogLockTableStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
 
-        RawSqlStatement createTableStatement = new RawSqlStatement("CREATE TABLE IF NOT EXISTS " +
-                database.escapeTableName(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogLockTableName()) +
-                " (ID INT, LOCKED BOOLEAN, LOCKGRANTED timestamp, LOCKEDBY TEXT, PRIMARY KEY (ID))");
+        RawSqlStatement createTableStatement = buildCreateTableStatement(
+                database.escapeTableName(
+                        database.getLiquibaseCatalogName(),
+                        database.getLiquibaseSchemaName(),
+                        database.getDatabaseChangeLogLockTableName())
+        );
 
         return SqlGeneratorFactory.getInstance().generateSql(createTableStatement, database);
 
+    }
+
+    protected static RawSqlStatement buildCreateTableStatement(String tableName) {
+        return new RawSqlStatement("CREATE TABLE IF NOT EXISTS " + tableName
+                + " (ID INT, LOCKED BOOLEAN, LOCKGRANTED timestamp, LOCKEDBY TEXT, PRIMARY KEY (ID))");
     }
 
 }

--- a/src/main/java/liquibase/ext/cassandra/sqlgenerator/DeleteGeneratorCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/sqlgenerator/DeleteGeneratorCassandra.java
@@ -1,12 +1,26 @@
 package liquibase.ext.cassandra.sqlgenerator;
 
+import liquibase.Scope;
 import liquibase.database.Database;
+import liquibase.exception.DatabaseException;
+import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.ext.cassandra.database.CassandraDatabase;
+import liquibase.ext.cassandra.lockservice.LockServiceCassandra;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.DeleteGenerator;
 import liquibase.statement.core.DeleteStatement;
+import liquibase.structure.core.PrimaryKey;
+import liquibase.structure.core.Table;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import static liquibase.ext.cassandra.database.CassandraDatabase.isAwsKeyspacesCompatibilityModeEnabled;
 
 public class DeleteGeneratorCassandra extends DeleteGenerator {
 
@@ -24,15 +38,70 @@ public class DeleteGeneratorCassandra extends DeleteGenerator {
 	public Sql[] generateSql(DeleteStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
 
 		if (statement.getWhere() == null) {
-
-			String sql = "TRUNCATE " + database
-					.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName());
-			return new Sql[] { new UnparsedSql(sql, getAffectedTable(statement)) };
+			if (isAwsKeyspacesCompatibilityModeEnabled()) {
+				Scope.getCurrentScope().getLog(DeleteGeneratorCassandra.class)
+						.fine("AWS Keyspaces compatibility mode enabled: using alternative queries to truncate " + statement.getTableName());
+				return buildDeleteStatements(statement, database, sqlGeneratorChain).toArray(new Sql[]{});
+			} else {
+				String sql = "TRUNCATE " + database.escapeTableName(statement.getCatalogName(),
+						statement.getSchemaName(), statement.getTableName());
+				return new Sql[] { new UnparsedSql(sql, getAffectedTable(statement)) };
+			}
 		} else {
-
 			return super.generateSql(statement, database, sqlGeneratorChain);
 		}
 
 	}
 
+	/**
+	 * Builds a list of DELETE statements to remove each row of a given table.
+	 *
+	 * @implNote Since AWS Keyspaces does not support TRUNCATE TABLE statements (see
+	 * <a href="https://docs.aws.amazon.com/keyspaces/latest/devguide/cassandra-apis.html#cassandra-api-support">
+	 * Cassandra APIs in AWS Keyspaces</a>), this method tries to build a DELETE statement for each row in the table
+	 * to truncate, when the AWS Keyspaces compatibility mode is enabled.
+	 * Here, we cannot simply drop then re-create the table because the delete generator is too generic, so we can't
+	 * easily know the structure of the table to re-create.
+	 *
+	 * @param statement 		The original DELETE statement not having any WHERE clause.
+	 * @param database  		The database where the queries will be executed.
+	 * @param sqlGeneratorChain The SQL generator chain.
+	 * @return The list of DELETE statements to execute to truncate the given table.
+	 * @throws UnexpectedLiquibaseException in case something goes wrong during the preparation of the statements.
+	 */
+	private List<Sql> buildDeleteStatements(final DeleteStatement statement, final Database database,
+											final SqlGeneratorChain sqlGeneratorChain) {
+		List<Sql> sqlStatements = new ArrayList<>();
+
+		String tableName = database.escapeTableName(statement.getCatalogName(),
+				statement.getSchemaName(), statement.getTableName());
+
+		// Get the primary key values of each row in the table.
+		Table table = (Table) getAffectedTable(statement);
+		PrimaryKey pk = table.getPrimaryKey();
+		String pkColumnNames = pk.getColumnNames();
+		String selectTableContent = "SELECT " + pkColumnNames + " FROM " + tableName;
+
+		// For each row in the table, build a DELETE statement for which the WHERE clause is based on the primary key
+		// of the row.
+		try {
+			Statement stmt = ((CassandraDatabase) database).getStatement();
+			ResultSet rs = stmt.executeQuery(selectTableContent);
+			while (rs.next()) {
+				DeleteStatement deleteRowStatement = new DeleteStatement(statement.getCatalogName(),
+						statement.getSchemaName(), statement.getTableName());
+				statement.addWhereColumnName(pkColumnNames);
+				for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
+					statement.addWhereParameter(rs.getObject(i));
+				}
+				sqlStatements.add(super.generateSql(deleteRowStatement, database, sqlGeneratorChain)[0]);
+			}
+			rs.close();
+			stmt.close();
+		} catch (DatabaseException | SQLException e) {
+			throw new UnexpectedLiquibaseException(
+					"Failed to build DELETE statements to truncate table " + tableName, e);
+		}
+		return sqlStatements;
+	}
 }

--- a/src/main/java/liquibase/ext/cassandra/sqlgenerator/InitializeDatabaseChangeLogLockTableGeneratorCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/sqlgenerator/InitializeDatabaseChangeLogLockTableGeneratorCassandra.java
@@ -1,7 +1,9 @@
 package liquibase.ext.cassandra.sqlgenerator;
 
+import liquibase.Scope;
 import liquibase.database.Database;
 import liquibase.ext.cassandra.database.CassandraDatabase;
+import liquibase.ext.cassandra.lockservice.LockServiceCassandra;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
@@ -10,6 +12,9 @@ import liquibase.statement.SqlStatement;
 import liquibase.statement.core.InitializeDatabaseChangeLogLockTableStatement;
 import liquibase.statement.core.InsertStatement;
 import liquibase.statement.core.RawSqlStatement;
+
+import static liquibase.ext.cassandra.database.CassandraDatabase.isAwsKeyspacesCompatibilityModeEnabled;
+import static liquibase.ext.cassandra.sqlgenerator.CreateDatabaseChangeLogLockTableGeneratorCassandra.buildCreateTableStatement;
 
 public class InitializeDatabaseChangeLogLockTableGeneratorCassandra extends InitializeDatabaseChangeLogLockTableGenerator {
 
@@ -26,18 +31,36 @@ public class InitializeDatabaseChangeLogLockTableGeneratorCassandra extends Init
     @Override
     public Sql[] generateSql(InitializeDatabaseChangeLogLockTableStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
 
-        RawSqlStatement deleteStatement = new RawSqlStatement("TRUNCATE TABLE " + database.escapeTableName(
+        SqlStatement[] statements;
+
+        String databaseChangelogLockTableName = database.escapeTableName(
                 database.getLiquibaseCatalogName(),
                 database.getLiquibaseSchemaName(),
-                database.getDatabaseChangeLogLockTableName().toUpperCase()));
+                database.getDatabaseChangeLogLockTableName().toUpperCase());
 
-        InsertStatement insertStatement = new InsertStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogLockTableName().toUpperCase())
+        InsertStatement insertStatement = new InsertStatement(database.getLiquibaseCatalogName(),
+                database.getLiquibaseSchemaName(), database.getDatabaseChangeLogLockTableName().toUpperCase())
                 .addColumnValue("ID", 1)
                 .addColumnValue("LOCKED", Boolean.FALSE);
 
-        return SqlGeneratorFactory.getInstance().generateSql(new SqlStatement[]{deleteStatement, insertStatement}, database);
+        if (isAwsKeyspacesCompatibilityModeEnabled()) {
+            // Since AWS Keyspaces does not support TRUNCATE TABLE statements
+            // (https://docs.aws.amazon.com/keyspaces/latest/devguide/cassandra-apis.html#cassandra-api-support), drop
+            // then re-create the changelog lock table when the AWS Keyspaces compatibility mode is enabled.
+            Scope.getCurrentScope().getLog(InitializeDatabaseChangeLogLockTableGeneratorCassandra.class)
+                    .fine("AWS Keyspaces compatibility mode enabled: using alternative queries to truncate changelog lock table");
+            RawSqlStatement dropStatement = new RawSqlStatement("DROP TABLE " + databaseChangelogLockTableName);
+            RawSqlStatement createStatement = buildCreateTableStatement(databaseChangelogLockTableName);
+
+            statements = new SqlStatement[]{dropStatement, createStatement, insertStatement};
+        } else {
+            RawSqlStatement deleteStatement = new RawSqlStatement("TRUNCATE TABLE " + databaseChangelogLockTableName);
+
+            statements = new SqlStatement[]{deleteStatement, insertStatement};
+        }
+
+        return SqlGeneratorFactory.getInstance().generateSql(statements, database);
 
     }
-
 
 }

--- a/src/main/java/liquibase/ext/cassandra/sqlgenerator/TagDatabaseGeneratorCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/sqlgenerator/TagDatabaseGeneratorCassandra.java
@@ -1,28 +1,26 @@
 package liquibase.ext.cassandra.sqlgenerator;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Timestamp;
-import java.text.SimpleDateFormat;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.util.Calendar;
-import java.util.TimeZone;
-
 import liquibase.Scope;
 import liquibase.database.Database;
 import liquibase.database.ObjectQuotingStrategy;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.exception.DatabaseException;
+import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.ext.cassandra.database.CassandraDatabase;
+import liquibase.ext.cassandra.lockservice.LockServiceCassandra;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.TagDatabaseGenerator;
 import liquibase.statement.core.TagDatabaseStatement;
-import liquibase.structure.core.Column;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+
+import static liquibase.ext.cassandra.database.CassandraDatabase.isAwsKeyspacesCompatibilityModeEnabled;
 
 public class TagDatabaseGeneratorCassandra extends TagDatabaseGenerator {
 
@@ -43,22 +41,45 @@ public class TagDatabaseGeneratorCassandra extends TagDatabaseGenerator {
 
 		try {
 			String tagEscaped = DataTypeFactory.getInstance().fromObject(statement.getTag(), database).objectToSql(statement.getTag(), database);
-			
 
 			Statement statement1 = ((CassandraDatabase) database).getStatement();
+			String databaseChangelogTableName = database.escapeTableName(database.getLiquibaseCatalogName(),
+					database.getLiquibaseSchemaName(), "databasechangelog");
+
 			//Query to get last executed changeset date
-			String query1 = "SELECT TOUNIXTIMESTAMP(MAX(DATEEXECUTED)) as DATEEXECUTED FROM " + 
-					database.escapeTableName(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), "databasechangelog");
-			ResultSet rs1 = statement1.executeQuery(query1);
+			ResultSet rs1;
+			PreparedStatement ps1 = null;
+			// When AWS Keyspaces compatibility mode is enabled, the max date must be calculated programmatically.
+			if (isAwsKeyspacesCompatibilityModeEnabled()) {
+				Scope.getCurrentScope().getLog(LockServiceCassandra.class)
+						.fine("AWS Keyspaces compatibility mode enabled: using alternative to get last executed changeset");
+				Timestamp maxDateExecuted = selectLastExecutedChangesetTimestamp(database, databaseChangelogTableName);
+				String query1 = "SELECT TOUNIXTIMESTAMP(DATEEXECUTED) as LAST_DATEEXECUTED FROM "
+						+ databaseChangelogTableName + "WHERE DATEEXECUTED = ? ALLOW FILTERING;";
+				ps1 = ((CassandraDatabase) database).prepareStatement(query1);
+				ps1.setTimestamp(1, maxDateExecuted);
+				rs1 = ps1.executeQuery();
+			} else {
+				String query1 = "SELECT TOUNIXTIMESTAMP(MAX(DATEEXECUTED)) as LAST_DATEEXECUTED FROM "
+						+ databaseChangelogTableName;
+				rs1 = statement1.executeQuery(query1);
+			}
 			String date = "";
+			if (rs1 == null) {
+				throw new UnexpectedLiquibaseException(
+						"Unexpected null result set when getting last executed changeset date");
+			}
 			while (rs1.next()) {
-				date =  rs1.getString("DATEEXECUTED");
+				date =  rs1.getString("LAST_DATEEXECUTED");
 			}
 			rs1.close();
+			if (ps1 != null) {
+				ps1.close();
+			}
+
 			//Query to get composite key details of last executed change set
-			String query2 = "select id,author, filename from " + 
-					database.escapeTableName(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), "databasechangelog")
-							+ " where dateexecuted = '"+date+"' ALLOW FILTERING";
+			String query2 = "SELECT id, author, filename FROM " + databaseChangelogTableName
+					+ " WHERE dateexecuted = '" + date + "' ALLOW FILTERING";
 			ResultSet rs2 = statement1.executeQuery(query2);
 			String id = "", author = "", filename = "";
 			while (rs2.next()) {
@@ -68,17 +89,16 @@ public class TagDatabaseGeneratorCassandra extends TagDatabaseGenerator {
 			}
 			rs2.close();
 			statement1.close();
+
 			//Query to update tag 
 			String updateQuery = "UPDATE " 
-					+ database.escapeTableName(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), "databasechangelog")
-					+ " SET TAG = "+tagEscaped
-					+ " WHERE id = '"+ id +"' and author = '"+ author +"' and filename = '"+ filename+ "'";
+					+ databaseChangelogTableName
+					+ " SET TAG = " + tagEscaped
+					+ " WHERE id = '" + id + "' AND author = '" + author + "' AND filename = '" + filename + "'";
 
 			return new Sql[]{
 				new UnparsedSql(updateQuery)
 			};
-
-			
 
 		} catch (SQLException | DatabaseException e) {
 			return super.generateSql(statement, database, sqlGeneratorChain);
@@ -86,4 +106,35 @@ public class TagDatabaseGeneratorCassandra extends TagDatabaseGenerator {
 			database.setObjectQuotingStrategy(currentStrategy);
 		}
 	}
+
+	/**
+	 * Gets the timestamp of the last executed changeset without using {@code MAX} aggregate function.
+	 *
+	 * @implNote Since aggregate functions like MAX are not supported by AWS Keyspaces (see
+	 * <a href="https://docs.aws.amazon.com/keyspaces/latest/devguide/cassandra-apis.html#cassandra-functions">
+	 * Cassandra functions in AWS Keyspaces</a>), this method tries to get all the values of the column DATEEXECUTED in
+	 * the table of the executed changesets to calculate and return the maximal value of this column.
+	 *
+	 * @param database 			 The database where the query is executed.
+	 * @param changelogTableName The name of the changelog table.
+	 * @return The timestamp of the last executed changeset.
+	 * @throws SQLException in case something goes wrong during the query execution.
+	 * @throws DatabaseException in case something goes wrong during the query execution.
+	 */
+	private Timestamp selectLastExecutedChangesetTimestamp(final Database database, final String changelogTableName)
+			throws SQLException, DatabaseException {
+		Statement statement = ((CassandraDatabase) database).getStatement();
+		ResultSet rs = statement.executeQuery("SELECT DATEEXECUTED FROM " + changelogTableName);
+		Timestamp maxValue = null;
+		while (rs.next()) {
+			Timestamp result = rs.getTimestamp("DATEEXECUTED");
+			if (maxValue == null || maxValue.compareTo(result) < 0) {
+				maxValue = result;
+			}
+		}
+		rs.close();
+		statement.close();
+		return maxValue;
+	}
+
 }

--- a/src/test/groovy/liquibase/ext/cassandra/database/CassandraDatabaseTest.groovy
+++ b/src/test/groovy/liquibase/ext/cassandra/database/CassandraDatabaseTest.groovy
@@ -1,5 +1,7 @@
 package liquibase.ext.cassandra.database
 
+import liquibase.Scope
+import liquibase.configuration.LiquibaseConfiguration
 import spock.lang.Specification
 
 class CassandraDatabaseTest extends Specification {
@@ -14,6 +16,11 @@ class CassandraDatabaseTest extends Specification {
         new CassandraDatabase().getDefaultDriver(null) == null
         new CassandraDatabase().getDefaultDriver("jdbc:mysql://localhost") == null
         new CassandraDatabase().getDefaultDriver("jdbc:cassandra://localhost") != null
+    }
+
+    def isAwsKeyspacesCompatibilityModeDisabledByDefault() {
+        expect:
+        !CassandraDatabase.isAwsKeyspacesCompatibilityModeEnabled()
     }
 
 }


### PR DESCRIPTION
This PR aims to solve #297 (and also #128). 

As discussed in the mentioned issue, it introduces a new property `liquibase.cassandra.awsKeyspacesCompatibilityModeEnabled` in the `liquibase.properties` file. Defining it to `true` means we are running against an AWS Keyspaces instance and need to use some alternative implementations to bypass the unimplemented CQL features in Keyspaces.

The different workarounds are:
* in `LockServiceCassandra`, it almost keeps the implementation done in #292 
* in `TagDatabaseGeneratorCassandra`, it introduces a query to get all the timestamps of the different changesets and determine the most recent one using pure Java (alternative to missing aggregate function `MAX()`).
* in `InitializeDatabaseChangeLogLockTableGeneratorCassandra`, it replaces the truncation of changelog lock table by a `DROP TABLE` then a `CREATE TABLE`
* in `DeleteGeneratorCassandra`, it replaces the truncation of the specified table by `DELETE` queries for each row of the table, based on their primary key. It's not optimal but as the `DeleteGenerator` is generic, we cannot easily re-create the truncated table.

I took advantage of these changes to fix some minor problems in README file, Javadoc and to improve some formatting.