### PR TITLE
Fix issue 297: incompatibility with AWS Keyspaces (complement)

### DIFF
--- a/src/main/java/liquibase/ext/cassandra/lockservice/LockServiceCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/lockservice/LockServiceCassandra.java
@@ -257,13 +257,13 @@ public class LockServiceCassandra extends StandardLockService {
                 attempt ++;
                 final String tableStatusSqlStatement = "SELECT status FROM system_schema_mcs.tables "
                         + "WHERE keyspace_name = '" + database.getLiquibaseCatalogName() + "'"
-                        + "AND table_name = " + tableName + "'";
+                        + "AND table_name = '" + tableName + "'";
                 String status = executor.queryForObject(new RawSqlStatement(tableStatusSqlStatement), String.class);
                 isTableActive = "ACTIVE".equalsIgnoreCase(status);
             } while (!isTableActive && attempt <= maxAttempts);
         } catch (final DatabaseException e) {
             Scope.getCurrentScope().getLog(LockServiceCassandra.class)
-                .warning("Failed to check the status of table " + tableName + " in AWS Keyspaces");
+                .warning("Failed to check the status of table " + tableName + " in AWS Keyspaces", e);
             return false;
         }
         return isTableActive;

--- a/src/main/java/liquibase/ext/cassandra/lockservice/LockServiceCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/lockservice/LockServiceCassandra.java
@@ -255,9 +255,10 @@ public class LockServiceCassandra extends StandardLockService {
                 Scope.getCurrentScope().getLog(LockServiceCassandra.class)
                         .fine("Checking the status of table " + tableName + " (attempt #" + attempt + ")...");
                 attempt ++;
+                // Note: the table name must be lowercase to match the name in the table 'system_schema_mcs.tables'
                 final String tableStatusSqlStatement = "SELECT status FROM system_schema_mcs.tables "
-                        + "WHERE keyspace_name = '" + database.getLiquibaseCatalogName() + "'"
-                        + "AND table_name = '" + tableName + "'";
+                        + "WHERE keyspace_name = '" + database.getLiquibaseCatalogName() + "' "
+                        + "AND table_name = '" + tableName.toLowerCase() + "'";
                 String status = executor.queryForObject(new RawSqlStatement(tableStatusSqlStatement), String.class);
                 isTableActive = "ACTIVE".equalsIgnoreCase(status);
             } while (!isTableActive && attempt <= maxAttempts);


### PR DESCRIPTION
This pull request closes #297 by adding a mechanism to wait before executing queries on newly created DATABASECHANGELOGLOCK table in AWS Keyspaces.  

@filipelautert I'll let you have a look to it. This has successfully been tested by @pasarbia (https://github.com/liquibase/liquibase-cassandra/issues/297#issuecomment-2283674814, thanks to her).