### PR TITLE
fix: add missing replaces method for Snapshot Generator

### DIFF
--- a/src/main/java/liquibase/ext/cassandra/snapshot/ColumnSnapshotGeneratorCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/snapshot/ColumnSnapshotGeneratorCassandra.java
@@ -7,6 +7,7 @@ import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
 import liquibase.ext.cassandra.database.CassandraDatabase;
 import liquibase.snapshot.DatabaseSnapshot;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.snapshot.jvm.ColumnSnapshotGenerator;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.DatabaseObject;
@@ -88,6 +89,11 @@ public class ColumnSnapshotGeneratorCassandra extends ColumnSnapshotGenerator {
         //TODO extend datatype parsing when needed to include DataTypeId
         column.setType(new DataType(rawColumnType));
         return column;
+    }
+
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{ColumnSnapshotGenerator.class};
     }
 
 }

--- a/src/main/java/liquibase/ext/cassandra/snapshot/IndexSnapshotGeneratorCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/snapshot/IndexSnapshotGeneratorCassandra.java
@@ -7,6 +7,7 @@ import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
 import liquibase.ext.cassandra.database.CassandraDatabase;
 import liquibase.snapshot.DatabaseSnapshot;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.snapshot.jvm.IndexSnapshotGenerator;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.DatabaseObject;
@@ -100,5 +101,9 @@ public class IndexSnapshotGeneratorCassandra extends IndexSnapshotGenerator {
         }
     }
 
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{IndexSnapshotGenerator.class};
+    }
 
 }

--- a/src/main/java/liquibase/ext/cassandra/snapshot/TableSnapshotGeneratorCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/snapshot/TableSnapshotGeneratorCassandra.java
@@ -88,4 +88,9 @@ public class TableSnapshotGeneratorCassandra extends TableSnapshotGenerator {
         return table;
     }
 
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{TableSnapshotGenerator.class};
+    }
+
 }


### PR DESCRIPTION
liquibase/liquibase#5775 was merged and fixed a bug where some snapshot generators were not being called.
But it also highlighted one issue at least in one OSS extension: if then extension replaces a core generator but is not implementing the replaces method, both generators may be invoked now.

This PR implements the missing replaces method.