### PR TITLE
refactor(ci): replace archived whelk-io with build-logic setup-maven-settings [DAT-22915]

### DIFF
--- a/.github/workflows/harness-tests.yml
+++ b/.github/workflows/harness-tests.yml
@@ -42,37 +42,10 @@ jobs:
         with:
           maven-version: "3.9.5"
 
-      - name: Configure Maven settings
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
         with:
-          repositories: |
-            [
-              {
-                "id": "liquibase",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": { "enabled": "true" },
-                "snapshots": { "enabled": "true", "updatePolicy": "always" }
-              },
-              {
-                "id": "liquibase-pro",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
-                "releases": { "enabled": "true" },
-                "snapshots": { "enabled": "true", "updatePolicy": "always" }
-              }
-            ]
-          servers: |
-            [
-              {
-                "id": "liquibase-pro",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              },
-              {
-                "id": "liquibase",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              }
-            ]
+          gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 
       - name: Start Cassandra 5
         working-directory: src/test/resources/docker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,37 +66,10 @@ jobs:
         with:
           maven-version: "3.9.5"
 
-      - name: Configure Maven settings
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
         with:
-          repositories: |
-            [
-              {
-                "id": "liquibase",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": { "enabled": "true" },
-                "snapshots": { "enabled": "true", "updatePolicy": "always" }
-              },
-              {
-                "id": "liquibase-pro",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
-                "releases": { "enabled": "true" },
-                "snapshots": { "enabled": "true", "updatePolicy": "always" }
-              }
-            ]
-          servers: |
-            [
-              {
-                "id": "liquibase-pro",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              },
-              {
-                "id": "liquibase",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              }
-            ]
+          gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 
       - name: Start Cassandra 5
         working-directory: src/test/resources/docker


### PR DESCRIPTION
## Summary

Replace both `whelk-io/maven-settings-xml-action` call sites (`.github/workflows/harness-tests.yml` and `.github/workflows/test.yml`) with the new first-party composite action [`liquibase/build-logic/.github/actions/setup-maven-settings`](https://github.com/liquibase/build-logic/pull/557).

Jira: [DAT-22915](https://datical.atlassian.net/browse/DAT-22915)

## Why

`whelk-io/maven-settings-xml-action` was **archived 2026-01-02** and flagged during the DAT-22654 supply-chain audit.

## What changed

Simple-mode invocation using the composite's defaults (releases-enabled=true matches existing config):
- **Repositories:** `liquibase` + `liquibase-pro` GPM (releases + snapshots enabled)
- **Servers:** both `liquibot` + `${{ env.LIQUIBOT_PAT_GPM_ACCESS }}`

## Blocked by

🚧 [**liquibase/build-logic#557**](https://github.com/liquibase/build-logic/pull/557) must merge first — `@main` won't resolve until the composite action lands on build-logic's main branch.

## Test plan

- [x] YAML parses cleanly (both files)
- [x] No remaining `whelk-io` references
- [x] `${{ env.LIQUIBOT_PAT_GPM_ACCESS }}` flows unchanged from pre-existing vault step
- [ ] CI green post-merge of liquibase/build-logic#557

🤖 Generated with [Claude Code](https://claude.com/claude-code)