### PR TITLE
ci: SHA-pin step-level build-logic action refs [TECHOPS-81]

### DIFF
--- a/.github/workflows/harness-tests.yml
+++ b/.github/workflows/harness-tests.yml
@@ -43,7 +43,7 @@ jobs:
           maven-version: "3.9.5"
 
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
           maven-version: "3.9.5"
 
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 


### PR DESCRIPTION
## Summary

Pins step-level uses of `liquibase/build-logic/.github/actions/*@main` in this repo to build-logic `main` HEAD `2660ba3`. Unblocks the GitHub enterprise policy **Require actions to be pinned to a full-length commit SHA**.

Context: [TECHOPS-81](https://datical.atlassian.net/browse/TECHOPS-81). Companion PR (no merge-order dependency, both can land independently): [liquibase/build-logic#605](https://github.com/liquibase/build-logic/pull/605).

## Maintenance trade-off

Future changes to the pinned composite action(s) in build-logic will require an explicit SHA bump in this repo. Dependabot may or may not propose these self-referential bumps automatically: watch the next weekly run after merge.

## Test plan

- [ ] CI green on this branch (workflows still resolve the pinned actions).
- [ ] After merge, confirm the affected workflow(s) still run end-to-end on a sample trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-81]: https://datical.atlassian.net/browse/TECHOPS-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ