### PR TITLE
fix: override tagExists to avoid ALLOW FILTERING error during rollback

### DIFF
--- a/src/main/java/liquibase/ext/cassandra/changelog/CassandraChangeLogHistoryService.java
+++ b/src/main/java/liquibase/ext/cassandra/changelog/CassandraChangeLogHistoryService.java
@@ -105,6 +105,22 @@ public class CassandraChangeLogHistoryService extends StandardChangeLogHistorySe
         return returnList;
     }
 
+    /**
+     * Override tagExists to avoid a WHERE clause on the TAG column, which is not part of the
+     * Cassandra primary key (ID, AUTHOR, FILENAME). A bare {@code WHERE TAG='...'} query would
+     * fail with "Cannot execute this query … use ALLOW FILTERING", and the COUNT(*) workaround
+     * is not supported by AWS Keyspaces. We reuse the already-correct full-table-scan from
+     * {@link #queryDatabaseChangeLogTable} and filter in Java instead.
+     */
+    @Override
+    public boolean tagExists(String tag) throws DatabaseException {
+        if (!hasDatabaseChangeLogTable()) {
+            return false;
+        }
+        List<Map<String, ?>> rows = queryDatabaseChangeLogTable(getDatabase());
+        return rows.stream().anyMatch(row -> tag.equals(row.get("TAG")));
+    }
+
     private String getChangeLogTableName() {
         if (getDatabase().getLiquibaseCatalogName() != null) {
             return getDatabase().getLiquibaseCatalogName() + "." + getDatabase().getDatabaseChangeLogTableName();

--- a/src/test/groovy/liquibase/ext/cassandra/changelog/CassandraChangeLogHistoryServiceTest.groovy
+++ b/src/test/groovy/liquibase/ext/cassandra/changelog/CassandraChangeLogHistoryServiceTest.groovy
@@ -1,6 +1,61 @@
 package liquibase.ext.cassandra.changelog
 
+import liquibase.database.Database
 import spock.lang.Specification
 
 class CassandraChangeLogHistoryServiceTest extends Specification {
+
+    def "tagExists returns true when a changeset with the matching tag exists"() {
+        given:
+        def service = Spy(CassandraChangeLogHistoryService) {
+            hasDatabaseChangeLogTable() >> true
+            getDatabase() >> Mock(Database)
+            queryDatabaseChangeLogTable(_) >> [
+                [ID: "1", AUTHOR: "dev", FILENAME: "db.sql", TAG: "v1.0"],
+                [ID: "2", AUTHOR: "dev", FILENAME: "db.sql", TAG: null]
+            ]
+        }
+
+        expect:
+        service.tagExists("v1.0")
+    }
+
+    def "tagExists returns false when no changeset carries the requested tag"() {
+        given:
+        def service = Spy(CassandraChangeLogHistoryService) {
+            hasDatabaseChangeLogTable() >> true
+            getDatabase() >> Mock(Database)
+            queryDatabaseChangeLogTable(_) >> [
+                [ID: "1", AUTHOR: "dev", FILENAME: "db.sql", TAG: "v1.0"]
+            ]
+        }
+
+        expect:
+        !service.tagExists("v2.0")
+    }
+
+    def "tagExists returns false when the DATABASECHANGELOG table does not exist"() {
+        given:
+        def service = Spy(CassandraChangeLogHistoryService) {
+            hasDatabaseChangeLogTable() >> false
+        }
+
+        expect:
+        !service.tagExists("v1.0")
+    }
+
+    def "tagExists handles null TAG values without throwing"() {
+        given:
+        def service = Spy(CassandraChangeLogHistoryService) {
+            hasDatabaseChangeLogTable() >> true
+            getDatabase() >> Mock(Database)
+            queryDatabaseChangeLogTable(_) >> [
+                [ID: "1", AUTHOR: "dev", FILENAME: "db.sql", TAG: null],
+                [ID: "2", AUTHOR: "dev", FILENAME: "db.sql", TAG: null]
+            ]
+        }
+
+        expect:
+        !service.tagExists("v1.0")
+    }
 }


### PR DESCRIPTION
## Problem

`liquibase rollback --tag <tag>` fails on Cassandra with:

```
InvalidQueryException: Cannot execute this query as it might involve data filtering
and thus may have unpredictable performance. If you want to execute this query
despite the performance unpredictability, use ALLOW FILTERING
```

### Root cause

`StandardChangeLogHistoryService.tagExists()` executes:

```sql
SELECT COUNT(*) FROM DATABASECHANGELOG WHERE TAG = '<tag>'
```

The `DATABASECHANGELOG` table is created with `PRIMARY KEY (ID, AUTHOR, FILENAME)`.
`TAG` is not part of the partition key, so any `WHERE TAG = ...` predicate requires
`ALLOW FILTERING` in Cassandra. On AWS Keyspaces the situation is worse — `COUNT(*)`
is not supported at all, so even adding `ALLOW FILTERING` would not help.

## Fix

Override `tagExists()` in `CassandraChangeLogHistoryService` to reuse the existing
full-table-scan from `queryDatabaseChangeLogTable()` (which already does a full
`SELECT` with no `WHERE` clause) and filter in Java. This is the same pattern already
used for `getRanChangeSets()` and works transparently on both vanilla Cassandra and
AWS Keyspaces.

## Changes

- `CassandraChangeLogHistoryService.java`: added `tagExists()` override
- `CassandraChangeLogHistoryServiceTest.groovy`: added 4 unit tests covering
  the match, no-match, table-absent, and null-TAG cases

## Testing

Unit tests run locally with Spock. Integration testing against a live Cassandra
cluster with `liquibase rollback --tag` confirmed the fix resolves the error.