### PR TITLE
fix: allow fork pr checkout on actions/checkout v7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,9 +50,10 @@ jobs:
           parse-json-secrets: true
 
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          allow-unsafe-pr-checkout: true
 
       - name: Set up JDK 21
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0


### PR DESCRIPTION
actions/checkout v7 refuses to check out fork pull request code from a pull_request_target workflow unless allow-unsafe-pr-checkout is set, so #472 as it stands would break CI for every external PR. Bumping test.yml here together with the flag, the remaining files in #472 are safe to merge after this.

Same fix as liquibase/liquibase#7833.
