### PR TITLE
fix(lock): fix lock acquisition race condition and eliminate ALLOW FILTERING anti-patterns

### DIFF
--- a/src/main/java/liquibase/ext/cassandra/lockservice/LockServiceCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/lockservice/LockServiceCassandra.java
@@ -221,8 +221,8 @@ public class LockServiceCassandra extends StandardLockService {
             }
 
             try {
-                isDatabaseChangeLogLockTableInitialized = executeCountQuery(executor,
-                        "SELECT COUNT(*) FROM " + getChangeLogLockTableName()) > 0;
+                isDatabaseChangeLogLockTableInitialized = !executor.queryForList(
+                        new RawSqlStatement("SELECT ID FROM " + getChangeLogLockTableName() + " WHERE ID = 1")).isEmpty();
             } catch (LiquibaseException e) {
                 if (executor.updatesDatabase()) {
                     throw new UnexpectedLiquibaseException(e);
@@ -236,15 +236,34 @@ public class LockServiceCassandra extends StandardLockService {
     }
 
     private boolean isLocked(Executor executor) throws DatabaseException {
-        return executeCountQuery(executor,
-                "SELECT COUNT(*) FROM " + getChangeLogLockTableName() + " WHERE LOCKED = TRUE ALLOW FILTERING") > 0;
+        List<Map<String, ?>> rows = executor.queryForList(
+                new RawSqlStatement("SELECT LOCKED FROM " + getChangeLogLockTableName() + " WHERE ID = 1"));
+        if (rows.isEmpty()) {
+            return false;
+        }
+        return parseBooleanColumn(getIgnoreCase(rows.get(0), "LOCKED"));
     }
 
     private boolean isLockedByCurrentInstance(Executor executor) throws DatabaseException {
         final String lockedBy = NetUtil.getLocalHostName() + " (" + NetUtil.getLocalHostAddress() + ")";
-        return executeCountQuery(executor,
-                "SELECT COUNT(*) FROM " + getChangeLogLockTableName() + " WHERE " +
-                        "LOCKED = TRUE AND LOCKEDBY = '" + lockedBy + "' ALLOW FILTERING") > 0;
+        List<Map<String, ?>> rows = executor.queryForList(
+                new RawSqlStatement("SELECT LOCKED, LOCKEDBY FROM " + getChangeLogLockTableName() + " WHERE ID = 1"));
+        if (rows.isEmpty()) {
+            return false;
+        }
+        Map<String, ?> row = rows.get(0);
+        boolean locked = parseBooleanColumn(getIgnoreCase(row, "LOCKED"));
+        Object lockedByValue = getIgnoreCase(row, "LOCKEDBY");
+        return locked && lockedBy.equals(lockedByValue != null ? lockedByValue.toString() : null);
+    }
+
+    private static boolean parseBooleanColumn(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        } else if (value instanceof Number) {
+            return ((Number) value).intValue() != 0;
+        }
+        return false;
     }
 
     private static Object getIgnoreCase(Map<String, ?> row, String key) {
@@ -257,35 +276,6 @@ public class LockServiceCassandra extends StandardLockService {
             return database.getLiquibaseCatalogName() + "." + database.getDatabaseChangeLogLockTableName();
         } else {
             return database.getDatabaseChangeLogLockTableName();
-        }
-    }
-
-    /**
-     * Execute a count query using an alternative if the AWS Keyspaces compatibility mode is enabled.
-     *
-     * @implNote Since aggregate functions like COUNT are not supported by AWS Keyspaces (see
-     * <a href="https://docs.aws.amazon.com/keyspaces/latest/devguide/cassandra-apis.html#cassandra-functions">
-     * Cassandra functions in AWS Keyspaces</a>), this method tries to execute the same query without the COUNT
-     * function then programmatically count returned rows, when the AWS Keyspaces compatibility mode is enabled.
-     *
-     * @param executor The query executor.
-     * @param query    The query to execute.
-     * @return The result of the count query.
-     * @throws DatabaseException in case something goes wrong during the query execution or if the provided query is
-     * not a count query.
-     */
-    private int executeCountQuery(final Executor executor, final String query) throws DatabaseException {
-        if (!query.contains("SELECT COUNT(*)")) {
-            throw new UnexpectedLiquibaseException("Invalid count query: " + query);
-        }
-        if (isAwsKeyspacesCompatibilityModeEnabled()) {
-            Scope.getCurrentScope().getLog(LockServiceCassandra.class)
-                    .fine("AWS Keyspaces compatibility mode enabled: using alternative count query");
-            final String altQuery = query.replaceAll("(?i)SELECT COUNT\\(\\*\\)", "SELECT *");
-            final List<Map<String, ?>> rows = executor.queryForList(new RawSqlStatement(altQuery));
-            return rows.size();
-        } else {
-            return executor.queryForInt(new RawSqlStatement(query));
         }
     }
 

--- a/src/main/java/liquibase/ext/cassandra/lockservice/LockServiceCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/lockservice/LockServiceCassandra.java
@@ -236,8 +236,8 @@ public class LockServiceCassandra extends StandardLockService {
     }
 
     private boolean isLocked(Executor executor) throws DatabaseException {
-        // Check to see if current process holds the lock each time
-        return isLockedByCurrentInstance(executor);
+        return executeCountQuery(executor,
+                "SELECT COUNT(*) FROM " + getChangeLogLockTableName() + " WHERE LOCKED = TRUE ALLOW FILTERING") > 0;
     }
 
     private boolean isLockedByCurrentInstance(Executor executor) throws DatabaseException {

--- a/src/test/groovy/liquibase/ext/cassandra/lockservice/LockServiceCassandraTest.groovy
+++ b/src/test/groovy/liquibase/ext/cassandra/lockservice/LockServiceCassandraTest.groovy
@@ -1,0 +1,143 @@
+package liquibase.ext.cassandra.lockservice
+
+import liquibase.executor.Executor
+import liquibase.ext.cassandra.database.CassandraDatabase
+import liquibase.statement.SqlStatement
+import liquibase.statement.core.RawSqlStatement
+import liquibase.util.NetUtil
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.lang.reflect.Method
+
+class LockServiceCassandraTest extends Specification {
+
+    LockServiceCassandra lockService
+    Executor executor
+    CassandraDatabase database
+
+    def setup() {
+        lockService = new LockServiceCassandra()
+        database = Mock(CassandraDatabase)
+        executor = Mock(Executor)
+        lockService.setDatabase(database)
+        database.getLiquibaseCatalogName() >> "betterbotz"
+        database.getDatabaseChangeLogLockTableName() >> "DATABASECHANGELOGLOCK"
+    }
+
+    // ─── isLocked ────────────────────────────────────────────────────────────
+
+    def "isLocked queries by partition key, not by ALLOW FILTERING"() {
+        given:
+        executor.queryForList(_) >> []
+
+        when:
+        callIsLocked()
+
+        then:
+        1 * executor.queryForList({ SqlStatement stmt ->
+            def sql = (stmt as RawSqlStatement).sql.toUpperCase()
+            sql.contains("WHERE ID = 1") && !sql.contains("ALLOW FILTERING")
+        }) >> []
+    }
+
+    @Unroll
+    def "isLocked returns #expected when LOCKED = #lockedValue"() {
+        given:
+        executor.queryForList(_) >> [[(locked): lockedValue]]
+
+        expect:
+        callIsLocked() == expected
+
+        where:
+        locked   | lockedValue    | expected
+        "LOCKED" | true           | true
+        "LOCKED" | false          | false
+        "locked" | Boolean.TRUE   | true
+        "locked" | Boolean.FALSE  | false
+        "LOCKED" | 1              | true
+        "LOCKED" | 0              | false
+    }
+
+    def "isLocked returns false when the lock table row is absent"() {
+        given:
+        executor.queryForList(_) >> []
+
+        expect:
+        !callIsLocked()
+    }
+
+    // ─── isLockedByCurrentInstance ───────────────────────────────────────────
+
+    def "isLockedByCurrentInstance queries by partition key, not by ALLOW FILTERING"() {
+        given:
+        executor.queryForList(_) >> []
+
+        when:
+        callIsLockedByCurrentInstance()
+
+        then:
+        1 * executor.queryForList({ SqlStatement stmt ->
+            def sql = (stmt as RawSqlStatement).sql.toUpperCase()
+            sql.contains("WHERE ID = 1") && !sql.contains("ALLOW FILTERING")
+        }) >> []
+    }
+
+    def "isLockedByCurrentInstance returns false when the lock table row is absent"() {
+        given:
+        executor.queryForList(_) >> []
+
+        expect:
+        !callIsLockedByCurrentInstance()
+    }
+
+    def "isLockedByCurrentInstance returns false when LOCKED = false"() {
+        given:
+        executor.queryForList(_) >> [[LOCKED: false, LOCKEDBY: currentLockedBy()]]
+
+        expect:
+        !callIsLockedByCurrentInstance()
+    }
+
+    def "isLockedByCurrentInstance returns false when locked by a different host"() {
+        given:
+        executor.queryForList(_) >> [[LOCKED: true, LOCKEDBY: "otherhost (9.9.9.9)"]]
+
+        expect:
+        !callIsLockedByCurrentInstance()
+    }
+
+    def "isLockedByCurrentInstance returns true when locked by this host"() {
+        given:
+        executor.queryForList(_) >> [[LOCKED: true, LOCKEDBY: currentLockedBy()]]
+
+        expect:
+        callIsLockedByCurrentInstance()
+    }
+
+    def "isLockedByCurrentInstance handles lowercase column names from JDBC driver"() {
+        given:
+        executor.queryForList(_) >> [[locked: true, lockedby: currentLockedBy()]]
+
+        expect:
+        callIsLockedByCurrentInstance()
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────────
+
+    private boolean callIsLocked() {
+        Method m = LockServiceCassandra.getDeclaredMethod("isLocked", Executor)
+        m.accessible = true
+        return m.invoke(lockService, executor) as boolean
+    }
+
+    private boolean callIsLockedByCurrentInstance() {
+        Method m = LockServiceCassandra.getDeclaredMethod("isLockedByCurrentInstance", Executor)
+        m.accessible = true
+        return m.invoke(lockService, executor) as boolean
+    }
+
+    private static String currentLockedBy() {
+        "${NetUtil.getLocalHostName()} (${NetUtil.getLocalHostAddress()})"
+    }
+}

--- a/src/test/groovy/liquibase/ext/cassandra/sqlgenerator/LockDatabaseChangeLogGeneratorCassandraTest.groovy
+++ b/src/test/groovy/liquibase/ext/cassandra/sqlgenerator/LockDatabaseChangeLogGeneratorCassandraTest.groovy
@@ -1,0 +1,38 @@
+package liquibase.ext.cassandra.sqlgenerator
+
+import liquibase.ext.cassandra.database.CassandraDatabase
+import liquibase.statement.core.LockDatabaseChangeLogStatement
+import spock.lang.Specification
+
+class LockDatabaseChangeLogGeneratorCassandraTest extends Specification {
+
+    def "generateSql includes IF LOCKED = FALSE to prevent concurrent lock acquisition"() {
+        given:
+        def generator = new LockDatabaseChangeLogGeneratorCassandra()
+        def database = Mock(CassandraDatabase)
+        database.escapeTableName(_, _, _) >> "betterbotz.DATABASECHANGELOGLOCK"
+        database.getDatabaseProductName() >> "Cassandra"
+
+        when:
+        def sql = generator.generateSql(new LockDatabaseChangeLogStatement(), database, null)
+
+        then:
+        sql.length > 0
+        sql[0].toSql().toUpperCase().contains("IF LOCKED = FALSE")
+    }
+
+    def "generateSql does not produce an unconditional UPDATE that would allow split-brain"() {
+        given:
+        def generator = new LockDatabaseChangeLogGeneratorCassandra()
+        def database = Mock(CassandraDatabase)
+        database.escapeTableName(_, _, _) >> "betterbotz.DATABASECHANGELOGLOCK"
+        database.getDatabaseProductName() >> "Cassandra"
+
+        when:
+        def sql = generator.generateSql(new LockDatabaseChangeLogStatement(), database, null)
+
+        then:
+        // The update must end with the IF condition, not a bare WHERE ID = 1
+        !sql[0].toSql().trim().toUpperCase().endsWith("WHERE ID = 1")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #107 — concurrent lock acquisition race condition.

### Root cause

The `LB-2097` merge (1675d8e) resolved a conflict incorrectly: `isLocked()` was left delegating to `isLockedByCurrentInstance()` instead of checking whether **any** node holds the lock. This meant nodes checking the lock while another held it would see `isLocked() = false` and proceed to issue a write — relying solely on the Cassandra lightweight transaction (LWT) that was added in the same merge.

### Changes

**1. Restore `isLocked()` to check any lock holder**

`isLocked()` now uses a partition-key point lookup and checks the `LOCKED` column directly, matching the original intent of the LB-2097 fix:

```cql
-- before (full scan, wrong semantics)
SELECT COUNT(*) FROM ... WHERE LOCKED = TRUE ALLOW FILTERING

-- after (partition-key lookup)
SELECT LOCKED FROM ... WHERE ID = 1
```

The three-step acquire protocol now works as originally designed:
1. `isLocked()` — short-circuit if the lock is already held by anyone
2. `UPDATE ... IF LOCKED = FALSE` — atomic LWT acquire (already correct)
3. `isLockedByCurrentInstance()` — confirm this node won the race

**2. Eliminate `SELECT COUNT(*) ALLOW FILTERING` anti-patterns**

`SELECT COUNT(*) ... ALLOW FILTERING` and `SELECT * ... ALLOW FILTERING` are full-table scans in Cassandra. Since `DATABASECHANGELOGLOCK` always has a single row keyed on `ID = 1`, all three query sites are replaced with direct partition-key lookups:

| Method | Before | After |
|---|---|---|
| `isLocked()` | `SELECT COUNT(*) WHERE LOCKED = TRUE ALLOW FILTERING` | `SELECT LOCKED WHERE ID = 1` |
| `isLockedByCurrentInstance()` | `SELECT COUNT(*) WHERE LOCKED = TRUE AND LOCKEDBY = '...' ALLOW FILTERING` | `SELECT LOCKED, LOCKEDBY WHERE ID = 1` |
| `isDatabaseChangeLogLockTableInitialized()` | `SELECT COUNT(*) FROM ...` | `SELECT ID WHERE ID = 1` |

Boolean and LOCKEDBY comparisons previously done in CQL are now done in Java after fetching the row, using a shared `parseBooleanColumn()` helper that handles both `Boolean` and `Number` driver representations (consistent with the existing `listLocks()` logic).

**3. Remove `executeCountQuery()`**

The `executeCountQuery()` helper existed to work around AWS Keyspaces' lack of `COUNT(*)` support. With all callers replaced by point lookups, it is no longer needed and is removed. The new queries work uniformly across standard Cassandra and AWS Keyspaces without special-casing.

## Test plan

- [ ] Verify lock acquisition succeeds for a single node
- [ ] Verify concurrent lock acquisition from two nodes results in exactly one acquiring the lock (the LWT guarantees this)
- [ ] Verify lock release works correctly
- [ ] Verify `isDatabaseChangeLogLockTableInitialized()` correctly detects initialized/uninitialized state
- [ ] Test against AWS Keyspaces with compatibility mode enabled
