### PR TITLE
fix(lock): fix lock acquisition race condition and eliminate ALLOW FILTERING anti-patterns

### DIFF
--- a/src/main/java/liquibase/ext/cassandra/lockservice/LockServiceCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/lockservice/LockServiceCassandra.java
@@ -221,8 +221,8 @@ public class LockServiceCassandra extends StandardLockService {
             }
 
             try {
-                isDatabaseChangeLogLockTableInitialized = executeCountQuery(executor,
-                        "SELECT COUNT(*) FROM " + getChangeLogLockTableName()) > 0;
+                isDatabaseChangeLogLockTableInitialized = !executor.queryForList(
+                        new RawSqlStatement("SELECT ID FROM " + getChangeLogLockTableName() + " WHERE ID = 1")).isEmpty();
             } catch (LiquibaseException e) {
                 if (executor.updatesDatabase()) {
                     throw new UnexpectedLiquibaseException(e);
@@ -236,15 +236,34 @@ public class LockServiceCassandra extends StandardLockService {
     }
 
     private boolean isLocked(Executor executor) throws DatabaseException {
-        // Check to see if current process holds the lock each time
-        return isLockedByCurrentInstance(executor);
+        List<Map<String, ?>> rows = executor.queryForList(
+                new RawSqlStatement("SELECT LOCKED FROM " + getChangeLogLockTableName() + " WHERE ID = 1"));
+        if (rows.isEmpty()) {
+            return false;
+        }
+        return parseBooleanColumn(getIgnoreCase(rows.get(0), "LOCKED"));
     }
 
     private boolean isLockedByCurrentInstance(Executor executor) throws DatabaseException {
         final String lockedBy = NetUtil.getLocalHostName() + " (" + NetUtil.getLocalHostAddress() + ")";
-        return executeCountQuery(executor,
-                "SELECT COUNT(*) FROM " + getChangeLogLockTableName() + " WHERE " +
-                        "LOCKED = TRUE AND LOCKEDBY = '" + lockedBy + "' ALLOW FILTERING") > 0;
+        List<Map<String, ?>> rows = executor.queryForList(
+                new RawSqlStatement("SELECT LOCKED, LOCKEDBY FROM " + getChangeLogLockTableName() + " WHERE ID = 1"));
+        if (rows.isEmpty()) {
+            return false;
+        }
+        Map<String, ?> row = rows.get(0);
+        boolean locked = parseBooleanColumn(getIgnoreCase(row, "LOCKED"));
+        Object lockedByValue = getIgnoreCase(row, "LOCKEDBY");
+        return locked && lockedBy.equals(lockedByValue != null ? lockedByValue.toString() : null);
+    }
+
+    private static boolean parseBooleanColumn(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        } else if (value instanceof Number) {
+            return ((Number) value).intValue() != 0;
+        }
+        return false;
     }
 
     private static Object getIgnoreCase(Map<String, ?> row, String key) {
@@ -257,35 +276,6 @@ public class LockServiceCassandra extends StandardLockService {
             return database.getLiquibaseCatalogName() + "." + database.getDatabaseChangeLogLockTableName();
         } else {
             return database.getDatabaseChangeLogLockTableName();
-        }
-    }
-
-    /**
-     * Execute a count query using an alternative if the AWS Keyspaces compatibility mode is enabled.
-     *
-     * @implNote Since aggregate functions like COUNT are not supported by AWS Keyspaces (see
-     * <a href="https://docs.aws.amazon.com/keyspaces/latest/devguide/cassandra-apis.html#cassandra-functions">
-     * Cassandra functions in AWS Keyspaces</a>), this method tries to execute the same query without the COUNT
-     * function then programmatically count returned rows, when the AWS Keyspaces compatibility mode is enabled.
-     *
-     * @param executor The query executor.
-     * @param query    The query to execute.
-     * @return The result of the count query.
-     * @throws DatabaseException in case something goes wrong during the query execution or if the provided query is
-     * not a count query.
-     */
-    private int executeCountQuery(final Executor executor, final String query) throws DatabaseException {
-        if (!query.contains("SELECT COUNT(*)")) {
-            throw new UnexpectedLiquibaseException("Invalid count query: " + query);
-        }
-        if (isAwsKeyspacesCompatibilityModeEnabled()) {
-            Scope.getCurrentScope().getLog(LockServiceCassandra.class)
-                    .fine("AWS Keyspaces compatibility mode enabled: using alternative count query");
-            final String altQuery = query.replaceAll("(?i)SELECT COUNT\\(\\*\\)", "SELECT *");
-            final List<Map<String, ?>> rows = executor.queryForList(new RawSqlStatement(altQuery));
-            return rows.size();
-        } else {
-            return executor.queryForInt(new RawSqlStatement(query));
         }
     }
 

--- a/src/test/groovy/liquibase/ext/cassandra/lockservice/LockServiceCassandraTest.groovy
+++ b/src/test/groovy/liquibase/ext/cassandra/lockservice/LockServiceCassandraTest.groovy
@@ -1,0 +1,143 @@
+package liquibase.ext.cassandra.lockservice
+
+import liquibase.executor.Executor
+import liquibase.ext.cassandra.database.CassandraDatabase
+import liquibase.statement.SqlStatement
+import liquibase.statement.core.RawSqlStatement
+import liquibase.util.NetUtil
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.lang.reflect.Method
+
+class LockServiceCassandraTest extends Specification {
+
+    LockServiceCassandra lockService
+    Executor executor
+    CassandraDatabase database
+
+    def setup() {
+        lockService = new LockServiceCassandra()
+        database = Mock(CassandraDatabase)
+        executor = Mock(Executor)
+        lockService.setDatabase(database)
+        database.getLiquibaseCatalogName() >> "betterbotz"
+        database.getDatabaseChangeLogLockTableName() >> "DATABASECHANGELOGLOCK"
+    }
+
+    // ─── isLocked ────────────────────────────────────────────────────────────
+
+    def "isLocked queries by partition key, not by ALLOW FILTERING"() {
+        given:
+        executor.queryForList(_) >> []
+
+        when:
+        callIsLocked()
+
+        then:
+        1 * executor.queryForList({ SqlStatement stmt ->
+            def sql = (stmt as RawSqlStatement).sql.toUpperCase()
+            sql.contains("WHERE ID = 1") && !sql.contains("ALLOW FILTERING")
+        }) >> []
+    }
+
+    @Unroll
+    def "isLocked returns #expected when LOCKED = #lockedValue"() {
+        given:
+        executor.queryForList(_) >> [[(locked): lockedValue]]
+
+        expect:
+        callIsLocked() == expected
+
+        where:
+        locked   | lockedValue    | expected
+        "LOCKED" | true           | true
+        "LOCKED" | false          | false
+        "locked" | Boolean.TRUE   | true
+        "locked" | Boolean.FALSE  | false
+        "LOCKED" | 1              | true
+        "LOCKED" | 0              | false
+    }
+
+    def "isLocked returns false when the lock table row is absent"() {
+        given:
+        executor.queryForList(_) >> []
+
+        expect:
+        !callIsLocked()
+    }
+
+    // ─── isLockedByCurrentInstance ───────────────────────────────────────────
+
+    def "isLockedByCurrentInstance queries by partition key, not by ALLOW FILTERING"() {
+        given:
+        executor.queryForList(_) >> []
+
+        when:
+        callIsLockedByCurrentInstance()
+
+        then:
+        1 * executor.queryForList({ SqlStatement stmt ->
+            def sql = (stmt as RawSqlStatement).sql.toUpperCase()
+            sql.contains("WHERE ID = 1") && !sql.contains("ALLOW FILTERING")
+        }) >> []
+    }
+
+    def "isLockedByCurrentInstance returns false when the lock table row is absent"() {
+        given:
+        executor.queryForList(_) >> []
+
+        expect:
+        !callIsLockedByCurrentInstance()
+    }
+
+    def "isLockedByCurrentInstance returns false when LOCKED = false"() {
+        given:
+        executor.queryForList(_) >> [[LOCKED: false, LOCKEDBY: currentLockedBy()]]
+
+        expect:
+        !callIsLockedByCurrentInstance()
+    }
+
+    def "isLockedByCurrentInstance returns false when locked by a different host"() {
+        given:
+        executor.queryForList(_) >> [[LOCKED: true, LOCKEDBY: "otherhost (9.9.9.9)"]]
+
+        expect:
+        !callIsLockedByCurrentInstance()
+    }
+
+    def "isLockedByCurrentInstance returns true when locked by this host"() {
+        given:
+        executor.queryForList(_) >> [[LOCKED: true, LOCKEDBY: currentLockedBy()]]
+
+        expect:
+        callIsLockedByCurrentInstance()
+    }
+
+    def "isLockedByCurrentInstance handles lowercase column names from JDBC driver"() {
+        given:
+        executor.queryForList(_) >> [[locked: true, lockedby: currentLockedBy()]]
+
+        expect:
+        callIsLockedByCurrentInstance()
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────────
+
+    private boolean callIsLocked() {
+        Method m = LockServiceCassandra.getDeclaredMethod("isLocked", Executor)
+        m.accessible = true
+        return m.invoke(lockService, executor) as boolean
+    }
+
+    private boolean callIsLockedByCurrentInstance() {
+        Method m = LockServiceCassandra.getDeclaredMethod("isLockedByCurrentInstance", Executor)
+        m.accessible = true
+        return m.invoke(lockService, executor) as boolean
+    }
+
+    private static String currentLockedBy() {
+        "${NetUtil.getLocalHostName()} (${NetUtil.getLocalHostAddress()})"
+    }
+}

--- a/src/test/groovy/liquibase/ext/cassandra/sqlgenerator/LockDatabaseChangeLogGeneratorCassandraTest.groovy
+++ b/src/test/groovy/liquibase/ext/cassandra/sqlgenerator/LockDatabaseChangeLogGeneratorCassandraTest.groovy
@@ -1,0 +1,38 @@
+package liquibase.ext.cassandra.sqlgenerator
+
+import liquibase.ext.cassandra.database.CassandraDatabase
+import liquibase.statement.core.LockDatabaseChangeLogStatement
+import spock.lang.Specification
+
+class LockDatabaseChangeLogGeneratorCassandraTest extends Specification {
+
+    def "generateSql includes IF LOCKED = FALSE to prevent concurrent lock acquisition"() {
+        given:
+        def generator = new LockDatabaseChangeLogGeneratorCassandra()
+        def database = Mock(CassandraDatabase)
+        database.escapeTableName(_, _, _) >> "betterbotz.DATABASECHANGELOGLOCK"
+        database.getDatabaseProductName() >> "Cassandra"
+
+        when:
+        def sql = generator.generateSql(new LockDatabaseChangeLogStatement(), database, null)
+
+        then:
+        sql.length > 0
+        sql[0].toSql().toUpperCase().contains("IF LOCKED = FALSE")
+    }
+
+    def "generateSql does not produce an unconditional UPDATE that would allow split-brain"() {
+        given:
+        def generator = new LockDatabaseChangeLogGeneratorCassandra()
+        def database = Mock(CassandraDatabase)
+        database.escapeTableName(_, _, _) >> "betterbotz.DATABASECHANGELOGLOCK"
+        database.getDatabaseProductName() >> "Cassandra"
+
+        when:
+        def sql = generator.generateSql(new LockDatabaseChangeLogStatement(), database, null)
+
+        then:
+        // The update must end with the IF condition, not a bare WHERE ID = 1
+        !sql[0].toSql().trim().toUpperCase().endsWith("WHERE ID = 1")
+    }
+}


### PR DESCRIPTION
to isLockedByCurrentInstance(), but the original intent was to check
whether *any* node holds the lock (WHERE LOCKED = TRUE). The wrong
delegation caused isLocked() to return false when another node held the
lock, sending every waiting node into an unnecessary LWT attempt rather
than short-circuiting cleanly.

The IF LOCKED = FALSE lightweight transaction in
LockDatabaseChangeLogGeneratorCassandra still prevents the actual double-
acquisition race, but the pre-check was semantically wrong and masked the
intent of the three-step acquire protocol described in issue liquibase#107:
  1. Check if lock is free (isLocked)
  2. Attempt atomic acquire with IF LOCKED = FALSE (LWT)
  3. Confirm current instance won (isLockedByCurrentInstance)

SELECT COUNT(*) ... ALLOW FILTERING and SELECT * ... ALLOW FILTERING are
full-table scans in Cassandra and a well-known anti-pattern. Since the
DATABASECHANGELOGLOCK table always has a single row keyed on ID=1, all
three lock-check queries can use a direct partition-key lookup instead:

  isLocked()                  → SELECT LOCKED FROM ... WHERE ID = 1
  isLockedByCurrentInstance() → SELECT LOCKED, LOCKEDBY FROM ... WHERE ID = 1
  isDatabaseChangeLogLockTableInitialized() → SELECT ID FROM ... WHERE ID = 1

Boolean comparisons previously done in CQL (LOCKED = TRUE) are now done
in Java after reading the row, using the existing parseBooleanColumn()
helper that handles both Boolean and Number driver representations.

The executeCountQuery() helper, which existed to paper over the
COUNT(*) AWS Keyspaces incompatibility, is no longer needed and is
removed. The point-lookup approach works uniformly across standard
Cassandra and AWS Keyspaces without any special-casing.

Fixes liquibase#107