### PR TITLE
fix(lock): verify lock ownership when rowsUpdated=0, not just -1

### DIFF
--- a/src/main/java/liquibase/ext/cassandra/lockservice/LockServiceCassandra.java
+++ b/src/main/java/liquibase/ext/cassandra/lockservice/LockServiceCassandra.java
@@ -75,14 +75,10 @@ public class LockServiceCassandra extends StandardLockService {
 
                 executor.comment("Lock Database");
                 int rowsUpdated = executor.update(new LockDatabaseChangeLogStatement());
-                if (rowsUpdated == -1 && !isLockedByCurrentInstance(executor)) {
-                    // another node was faster
-                    return false;
-                }
                 if (rowsUpdated > 1) {
                     throw new LockException("Did not update change log lock correctly");
                 }
-                if (rowsUpdated == 0) {
+                if (lockAcquisitionInconclusive(rowsUpdated) && !isLockedByCurrentInstance(executor)) {
                     // another node was faster
                     return false;
                 }
@@ -233,6 +229,15 @@ public class LockServiceCassandra extends StandardLockService {
             }
         }
         return isDatabaseChangeLogLockTableInitialized;
+    }
+
+    /**
+     * The applied-row count reported by the LWT-backed lock UPDATE isn't a reliable success signal on its own:
+     * some JDBC option sets report -1 (unknown), and others report 0 even when the conditional apply actually
+     * succeeded. Both counts require verifying lock ownership directly rather than assuming the update failed.
+     */
+    private boolean lockAcquisitionInconclusive(int rowsUpdated) {
+        return rowsUpdated == -1 || rowsUpdated == 0;
     }
 
     private boolean isLocked(Executor executor) throws DatabaseException {

--- a/src/test/groovy/liquibase/ext/cassandra/lockservice/LockServiceCassandraTest.groovy
+++ b/src/test/groovy/liquibase/ext/cassandra/lockservice/LockServiceCassandraTest.groovy
@@ -67,6 +67,20 @@ class LockServiceCassandraTest extends Specification {
         !callIsLocked()
     }
 
+    // ─── lockAcquisitionInconclusive ─────────────────────────────────────────
+
+    @Unroll
+    def "lockAcquisitionInconclusive returns #expected for rowsUpdated=#rowsUpdated"() {
+        expect:
+        callLockAcquisitionInconclusive(rowsUpdated) == expected
+
+        where:
+        rowsUpdated | expected
+        -1          | true   // driver reports "unknown affected rows" for the LWT-backed UPDATE
+        0           | true   // some JDBC option sets report 0 even when the conditional apply succeeded
+        1           | false  // unambiguous single-row success
+    }
+
     // ─── isLockedByCurrentInstance ───────────────────────────────────────────
 
     def "isLockedByCurrentInstance queries by partition key, not by ALLOW FILTERING"() {
@@ -135,6 +149,12 @@ class LockServiceCassandraTest extends Specification {
         Method m = LockServiceCassandra.getDeclaredMethod("isLockedByCurrentInstance", Executor)
         m.accessible = true
         return m.invoke(lockService, executor) as boolean
+    }
+
+    private boolean callLockAcquisitionInconclusive(int rowsUpdated) {
+        Method m = LockServiceCassandra.getDeclaredMethod("lockAcquisitionInconclusive", int)
+        m.accessible = true
+        return m.invoke(lockService, rowsUpdated) as boolean
     }
 
     private static String currentLockedBy() {


### PR DESCRIPTION
## Summary

Fixes #379.

`LockServiceCassandra.acquireLock()` already had a fallback for when the JDBC driver reports `-1` (unknown) affected rows for the LWT-backed lock `UPDATE`: it verifies actual lock ownership via a `SELECT` before concluding the acquisition failed. But it treated `rowsUpdated == 0` as an unconditional failure, with no such verification.

As diagnosed in #379, some JDBC option sets (e.g. the default `cassandra-jdbc-wrapper` option set, as opposed to the `Liquibase` option set) report `0` even when the conditional apply actually succeeded. That caused `acquireLock()` to misinterpret a successful lock acquisition as a loss to another node, and the caller (`liquibase-maven-plugin` in the reported case) would spin forever retrying a lock it had already acquired.

## Changes

- Extracted the ambiguous-row-count check into `lockAcquisitionInconclusive(int)` and apply the same `isLockedByCurrentInstance()` verification fallback to both `-1` and `0`, instead of only `-1`.
- This makes lock acquisition correctness independent of which JDBC option set's row-count convention is in play, rather than requiring users to manually select a specific option set as a workaround.

## Test plan

- Added unit tests for `lockAcquisitionInconclusive` covering `-1`, `0`, and `1`.
- `mvn test` — all 32 tests pass.